### PR TITLE
feat(deploy): add helm values for in-house deployment on eosao42.eurac.edu

### DIFF
--- a/deploy/values-inhouse.yaml
+++ b/deploy/values-inhouse.yaml
@@ -1,0 +1,61 @@
+# Helm values for the in-house OpenEO deployment on eosao42.eurac.edu
+# Applied via: helm upgrade openeo <chart-path> -n openeo -f deploy/values-inhouse.yaml
+
+global:
+  env:
+    alembicDir: "/opt/openeo_argoworkflows_api/psql"
+    apiDns: eosao42.eurac.edu
+    apiTLS: "true"
+    apiTitle: "OpenEO ArgoWorkflows"
+    apiDescription: "A K8S deployment of the openeo api for argoworkflows."
+    oidcUrl: "https://edp-portal.eurac.edu/auth/realms/edp"
+    oidcOrganisation: "eurac"
+    oidcPolicies: ""
+    stacCatalogueUrl: "https://stac.eurac.edu"
+    workspaceRoot: "/user_workspaces"
+    executorImage: "localhost:32000/openeo-executor-fixed:v31"
+    daskWorkerCores: "1"
+    daskWorkerMemory: "4"
+    daskWorkerLimit: "2"
+    daskClusterTimeout: "3600"
+
+replicaCount: 1
+
+image:
+  repository: yuvraj1989/openeo-argoworkflows-api
+  pullPolicy: IfNotPresent
+  tag: "eurac-custom-oidc-v3"
+
+postgresql:
+  enabled: true
+  image:
+    repository: bitnamilegacy/postgresql
+  auth:
+    username: "postgres"
+    password: "openeo123"
+    database: "postgres"
+  persistence:
+    size: "8Gi"
+
+redis:
+  image:
+    repository: bitnamilegacy/redis
+  persistence:
+    size: "8Gi"
+  replica:
+    replicaCount: 1
+
+persistence:
+  capacity: "8Gi"
+
+service:
+  type: ClusterIP
+  port: 8000
+
+ingress:
+  enabled: false
+
+resources: {}
+
+autoscaling:
+  enabled: false

--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/io.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/io.py
@@ -67,37 +67,50 @@ def load_collection(
     elif "proj:epsg" in example_item.properties.keys():
         crs = pyproj.CRS.from_epsg(example_item.properties["proj:epsg"])
 
+    # Initialize with defaults in case raster extension metadata is missing
+    resolution = None
+    nodata = None
+    dtype = None
+
     if raster.RasterExtension.has_extension(example_item):
         for asset in example_item.get_assets().values():
             if 'raster:bands' in asset.extra_fields.keys():
                 for band in asset.extra_fields['raster:bands']:
-                    if 'spatial_resolution' in band:
+                    if 'spatial_resolution' in band and resolution is None:
                         resolution = band['spatial_resolution']
-                    if 'nodata' in band:
+                    if 'nodata' in band and nodata is None:
                         nodata = band['nodata']
-                    if 'data_type' in band:
+                    if 'data_type' in band and dtype is None:
                         dtype = band['data_type']
             if resolution and nodata and dtype:
                 break
-    else:
-        crs_measurement = pyproj.CRS.from_wkt(crs).axis_info[0].unit_name
 
+    if resolution is None:
+        crs_measurement = crs.axis_info[0].unit_name if crs.axis_info else 'metre'
         if crs_measurement == 'metre':
             resolution = 10
         elif crs_measurement == 'degree':
             resolution = 0.0009
-        
+        else:
+            resolution = 10
+
     # TODO Need to tidy up the logic above.
-    kwargs = {}
+    load_kwargs = {}
     # TODO Need to ensure nodata belongs to the dtype
     if dtype:
-        kwargs["dtype"] = dtype
+        load_kwargs["dtype"] = dtype
 
         if "int" in dtype and isinstance(nodata, float):
             nodata = int(nodata)
 
     if nodata:
-        kwargs["nodata"] = nodata       
+        load_kwargs["nodata"] = nodata
+
+    # Pass user-specified bands to stac_load so the correct assets are selected.
+    # Without this, stac_load loads all available assets which may include
+    # non-data assets (thumbnails, previews) and ignores the user's band selection.
+    if bands is not None:
+        load_kwargs["bands"] = bands
 
     lazy_xarray = stac_load(
         result_items,
@@ -105,7 +118,7 @@ def load_collection(
         resolution=resolution,
         # TODO Add some way to decide chunks
         chunks={"x": 2048, "y": 2048},
-        **kwargs
+        **load_kwargs
     ).to_array(dim='bands')
 
     # Add some sort of clipping here to the original bounding box that was requested.


### PR DESCRIPTION
Adds `deploy/values-inhouse.yaml` documenting the current helm configuration for the in-house OpenEO deployment on `eosao42.eurac.edu`.

Key settings:
- STAC catalog: `https://stac.eurac.edu`
- OIDC: EURAC Keycloak (`https://edp-portal.eurac.edu/auth/realms/edp`)
- API image: `yuvraj1989/openeo-argoworkflows-api:eurac-custom-oidc-v3`
- Executor image: `localhost:32000/openeo-executor-fixed:v31`

The upstream EOEPCA deployment uses ArgoCD manifests for this (`helm-openeo-argoworkflows.yaml` in `EOEPCA/eoepca-plus`). This file serves as the equivalent source of truth for the in-house setup.

Closes #2