### PR TITLE
feat(api): CI build for API image with OIDC patches on ghcr.io

### DIFF
--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -1,0 +1,50 @@
+name: Build and publish API image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'openeo_argoworkflows/api/**'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/openeo-argoworkflows-api
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: openeo_argoworkflows/api
+          file: openeo_argoworkflows/api/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: prod

--- a/openeo_argoworkflows/api/Dockerfile
+++ b/openeo_argoworkflows/api/Dockerfile
@@ -21,6 +21,11 @@ ENV PATH="${POETRY_HOME}/bin:${VIRTUAL_ENV}/bin:${PATH}"
 
 RUN poetry install --only main
 
+# Patch openeo-fastapi library: replace hardcoded EGI Check-in with env-based OIDC config,
+# and disable JWT audience validation for EURAC Keycloak compatibility.
+COPY ./patches/openeo_fastapi_core.py ${VIRTUAL_ENV}/lib/python3.11/site-packages/openeo_fastapi/client/core.py
+COPY ./patches/openeo_fastapi_auth.py ${VIRTUAL_ENV}/lib/python3.11/site-packages/openeo_fastapi/client/auth.py
+
 COPY --chown=${USER_ID}:${GROUP_ID} ./openeo_argoworkflows_api /opt/openeo_argoworkflows_api
 
 RUN addgroup --gid ${GROUP_ID} ${USERNAME}

--- a/openeo_argoworkflows/api/patches/openeo_fastapi_auth.py
+++ b/openeo_argoworkflows/api/patches/openeo_fastapi_auth.py
@@ -1,0 +1,317 @@
+"""Class and model to define the framework and partial application logic for interacting with Jobs.
+
+Classes:
+    - User: Framework for defining and extending the logic for working with BatchJobs.
+    - Authenticator: Class holding the abstract validation method used for authentication for API endpoints.
+    - AuthMethod: Enum defining the available auth methods.
+    - AuthToken: Pydantic model for breaking and validating an OpenEO Token into it's consituent parts.
+    - IssuerHandler: Class for handling the AuthToken and validating against the revelant token Issuer and AuthMethod.
+"""
+import datetime
+import uuid
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import List
+
+import requests
+from fastapi import Header, HTTPException
+from jose import jwt
+from pydantic import BaseModel, ValidationError, validator
+
+from openeo_fastapi.api.types import Error
+from openeo_fastapi.client.psql.engine import Filter, create, get_first_or_default
+from openeo_fastapi.client.psql.models import UserORM
+from openeo_fastapi.client.settings import AppSettings
+
+ALGORITHMS = ["RS256"]
+OIDC_WELLKNOWN_CONFIG_PATH = "/.well-known/openid-configuration"
+OIDC_USERINFO = "userinfo_endpoint"
+OIDC_JWKS = "jwks_uri"
+
+
+class User(BaseModel):
+    """Pydantic model manipulating users."""
+
+    user_id: uuid.UUID
+    oidc_sub: str
+    created_at: datetime.datetime = datetime.datetime.utcnow()
+
+    class Config:
+        """Pydantic model class config."""
+
+        orm_mode = True
+        arbitrary_types_allowed = True
+        extra = "ignore"
+
+    @classmethod
+    def get_orm(cls):
+        """Get the ORM model for this pydantic model."""
+        return UserORM
+
+
+# TODO Might make more sense to merge with IssueHandler class.
+# TODO The validate function needs to be easier to overwrite and inject into the OpenEO Core client.
+class Authenticator(ABC):
+    """Basic class to hold the validation call to be used by the api endpoints requiring authentication."""
+
+    # Authenticator validate method needs to know what decisions to make based on user info response from the issuer handler.
+    # This will be different for different backends, so just put it as ABC for now. We might be able to define this if we want
+    # to specify an auth config when initialising the backend.
+    @abstractmethod
+    def validate(authorization: str = Header()):
+        """Validate the authorisation header and create a new user. This method can be overwritten as needed.
+
+        Args:
+            authorization (str): The authorisation header content from the request headers.
+
+        Returns:
+            User: The authenticated user.
+        """
+        settings = AppSettings()
+
+        policies = None
+        if settings.OIDC_POLICIES:
+            policies = settings.OIDC_POLICIES
+        issuer = IssuerHandler(issuer_uri=settings.OIDC_URL, policies=policies)
+
+        user_info = issuer.validate_token(authorization)
+
+        found_user = get_first_or_default(
+            User, Filter(column_name="oidc_sub", value=user_info["sub"])
+        )
+
+        if found_user:
+            return found_user
+
+        user = User(user_id=uuid.uuid4(), oidc_sub=user_info["sub"])
+
+        create(create_object=user)
+        return user
+
+
+class AuthMethod(Enum):
+    """Enum defining known auth methods."""
+
+    BASIC = "basic"
+    OIDC = "oidc"
+
+
+# Breaks the OpenEO token format down into it's components. This makes it possible to use the token against the issuer.
+class AuthToken(BaseModel):
+    """The AuthToken breaks down the OpenEO token into its consituent parts to be used for validation."""
+
+    method: AuthMethod
+    provider: str
+    token: str
+
+    @validator("provider", pre=True)
+    def check_provider(cls, v, values, **kwargs):
+        if v == "":
+            raise ValidationError("Empty provider string.")
+        return v
+
+    @validator("token", pre=True)
+    def check_token(cls, v, values, **kwargs):
+        if v == "":
+            raise ValidationError("Empty token string.")
+        return v
+
+    @classmethod
+    def from_token(cls, token: str):
+        """Takes the openeo format token, splits it into the component parts, and returns an Auth token."""
+
+        if "Bearer " in token:
+            token = token.removeprefix("Bearer ")
+
+        return cls(**dict(zip(["method", "provider", "token"], token.split("/"))))
+
+
+class IssuerHandler(BaseModel):
+    """General token handler for querying provided tokens against issuers."""
+
+    issuer_uri: str
+    policies: list[str] = None
+
+    @validator("issuer_uri", pre=True)
+    def remove_trailing_slash(cls, v, values, **kwargs):
+        if v.endswith("/"):
+            return v.removesuffix("/")
+        return v
+
+    def _get_issuer_config(self):
+        """Get the well known config of the issuer url.
+
+        Returns:
+            Direct response object from the request.
+        """
+        return requests.get(self.issuer_uri + OIDC_WELLKNOWN_CONFIG_PATH)
+
+    def _get_user_info(self, info_endpoint, token):
+        """Get the user info from  known config of the issuer url.
+
+        Args:
+            info_endpoint (str): The url of the user info endpoint to request.
+            token (str): The token to be used as the bearer token in the authorization header.
+
+        Returns:
+            Direct response object from the request.
+        """
+        return requests.get(
+            info_endpoint,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {token}",
+            },
+        )
+
+    def _get_oidc_jwks(self, issuer_config):
+        """Get the jwks uri from the issuer config.
+
+        Args:
+            issuer_config (dict): The url of the user info endpoint to request.
+
+        Returns:
+            Direct response object from the request.
+        """
+        jwks_uri = issuer_config.json()[OIDC_JWKS]
+        return requests.get(jwks_uri)
+
+    def _validate_token(self, token, jwks):
+        """Ensure the token is valid by verifying the token using the jwts of the issuer.
+
+        Args:
+            token (str): The token to be checked.
+            jwks (dict): The jwks from the issuer.
+
+        Returns:
+            Payload (dict): True represents a valid token, False invalid..
+        """
+        # Decode the JWT token without validation to extract the header
+        unverified_header = jwt.get_unverified_header(token)
+
+        # Find the correct key to verify the token signature
+        rsa_key = {}
+        for key in jwks:
+            if key["kid"] == unverified_header["kid"]:
+                rsa_key = {
+                    "kty": key["kty"],
+                    "kid": key["kid"],
+                    "use": key["use"],
+                    "n": key["n"],
+                    "e": key["e"],
+                }
+                break
+        if rsa_key:
+            # Validate the token and verify claims
+            # EURAC FIX: Disable audience validation as Keycloak tokens have 'aud' set to 'account'
+            # which doesn't match any expected audience. The issuer validation is still performed.
+            payload = jwt.decode(
+                token, rsa_key, algorithms=ALGORITHMS, issuer=self.issuer_uri,
+                options={"verify_aud": False}
+            )
+            return payload
+
+    def _authenticate_oidc_user(self, token: str):
+        """Validate the provided oidc token against the oidc provider.
+
+        Args:
+            token (str): The token to be used as the bearer token in the authorization header.
+
+        Raises:
+            HTTPException: Raises an exception with relevant status code and descriptive message of failure.
+
+        Returns:
+            JSON from the response object from the request.
+        """
+
+        issuer_oidc_config = self._get_issuer_config()
+
+        if issuer_oidc_config.status_code != 200:
+            raise HTTPException(
+                status_code=500,
+                detail=Error(
+                    code="InvalidIssuerConfig",
+                    message="The issuer config is not available. Tokens cannot be validated currently. Try again later.",
+                ),
+            )
+
+        jwks_resp = self._get_oidc_jwks(issuer_oidc_config)
+
+        if issuer_oidc_config.status_code != 200:
+            raise HTTPException(
+                status_code=500,
+                detail=Error(
+                    code="InvalidIssuerConfig",
+                    message=f"Key: jwks_uri is not available at the oidc config {OIDC_WELLKNOWN_CONFIG_PATH} location.",
+                ),
+            )
+
+        jwks = jwks_resp.json()["keys"]
+
+        if self._validate_token(token, jwks):
+            # We can see if the user can be authenticated.
+            userinfo_uri = issuer_oidc_config.json()[OIDC_USERINFO]
+
+            resp = self._get_user_info(userinfo_uri, token)
+            if resp.status_code != 200:
+                raise HTTPException(
+                    status_code=500,
+                    detail=Error(
+                        code="InvalidIssuerConfig",
+                        message=f"Key: {OIDC_USERINFO} is not available at the oidc config {OIDC_WELLKNOWN_CONFIG_PATH} location.",
+                    ),
+                )
+
+            userinfo = resp.json()
+
+            # If policies have been set for this provider, only allow users who match.
+            if self.policies:
+                for policy in self.policies:
+                    key, value = policy.split(",")
+
+                    for info in userinfo[key]:
+                        if info == value:
+                            return userinfo
+
+                raise HTTPException(
+                    status_code=500,
+                    detail=Error(
+                        code="TokenInvalid",
+                        message=f"No existing access policy applies to user. Contact backend provider.",
+                    ),
+                )
+
+            return userinfo
+
+        raise HTTPException(
+            status_code=500,
+            detail=Error(
+                code="TokenInvalid", message=f"The provided token is not valid."
+            ),
+        )
+
+    def validate_token(self, token: str):
+        """Try to validate the token against the give OIDC provider.
+
+        Args:
+            token (str): The OpenEO token to be parsed and validated against the oidc provider.
+
+        Raises:
+            HTTPException: Raises an exception with relevant status code and descriptive message of failure.
+
+        Returns:
+            The JSON as dictionary from _validate_oidc_token.
+        """
+        # TODO Handle validation exceptions
+        parsed_token = AuthToken.from_token(token)
+
+        if parsed_token.method.value == AuthMethod.OIDC.value:
+            return self._authenticate_oidc_user(parsed_token.token)
+
+        raise HTTPException(
+            status_code=500,
+            detail=Error(
+                code="TokenCantBeValidated",
+                message=f"The provided token cannot be validated.",
+            ),
+        )

--- a/openeo_argoworkflows/api/patches/openeo_fastapi_core.py
+++ b/openeo_argoworkflows/api/patches/openeo_fastapi_core.py
@@ -1,0 +1,236 @@
+"""Class and model to define the framework and partial application logic for interacting with Jobs.
+
+Classes:
+    - OpenEOCore: Framework for defining the application logic that will passed onto the OpenEO Api.
+"""
+from collections import namedtuple
+from typing import Optional
+from urllib.parse import urlunparse
+
+from attrs import define, field
+from fastapi import Depends, HTTPException, Response
+
+from openeo_fastapi.api.models import (
+    Capabilities,
+    ConformanceGetResponse,
+    CredentialsOidcGetResponse,
+    DefaultClient,
+    FileFormatsGetResponse,
+    GrantType,
+    MeGetResponse,
+    Provider,
+    UdfRuntimesGetResponse,
+    WellKnownOpeneoGetResponse,
+)
+from openeo_fastapi.api.types import Endpoint, Error, STACConformanceClasses, Version
+from openeo_fastapi.client.auth import Authenticator, User
+from openeo_fastapi.client.collections import CollectionRegister
+from openeo_fastapi.client.files import FilesRegister
+from openeo_fastapi.client.jobs import JobsRegister
+from openeo_fastapi.client.processes import ProcessRegister
+from openeo_fastapi.client.settings import AppSettings
+
+APPLICATION_ENDPOINTS = [
+    Endpoint(
+        path="/",
+        methods=["GET"],
+    ),
+    Endpoint(
+        path="/.well-known/openeo",
+        methods=["GET"],
+    ),
+    Endpoint(
+        path="/conformance",
+        methods=["GET"],
+    ),
+    Endpoint(
+        path="/credentials/oidc",
+        methods=["GET"],
+    ),
+]
+
+
+@define
+class OpenEOCore:
+    """Client for defining the application logic for the OpenEO Api."""
+
+    billing: str = field()
+    input_formats: list = field()
+    output_formats: list = field()
+    links: list = field()
+
+    settings: AppSettings = None
+
+    _id: str = field(default="OpenEOApi")
+
+    collections: Optional[CollectionRegister] = None
+    files: Optional[FilesRegister] = None
+    jobs: Optional[JobsRegister] = None
+    processes: Optional[ProcessRegister] = None
+
+    endpoints = APPLICATION_ENDPOINTS
+
+    def __attrs_post_init__(self):
+        """Post init hook to set the client registers, if none where provided by the user set to the defaults!"""
+        self.settings = AppSettings()
+
+        self.collections = self.collections or CollectionRegister(self.settings)
+        self.files = self.files or FilesRegister(self.settings, self.links)
+        self.jobs = self.jobs or JobsRegister(self.settings, self.links)
+        self.processes = self.processes or ProcessRegister(self.links)
+
+    def _combine_endpoints(self):
+        """For the various registers that hold endpoint functions, concat those endpoints to register in get_capabilities.
+
+        Returns:
+            List: A list of all the endpoints that will be supported by this api deployment.
+        """
+        registers = [self.collections, self.files, self.jobs, self.processes]
+
+        endpoints = self.endpoints
+        for register in registers:
+            if register:
+                endpoints.extend(register.endpoints)
+        return endpoints
+
+    def get_capabilities(self) -> Capabilities:
+        """Get the capabilities of the api.
+
+        Returns:
+            Capabilities: The capabilities of the api based off what the user provided.
+        """
+        return Capabilities(
+            id=self._id,
+            title=self.settings.API_TITLE,
+            stac_version=self.settings.STAC_VERSION,
+            api_version=self.settings.OPENEO_VERSION,
+            description=self.settings.API_DESCRIPTION,
+            backend_version=self.settings.OPENEO_VERSION,
+            billing=self.billing,
+            links=self.links,
+            endpoints=self._combine_endpoints(),
+        )
+
+    def get_credentials_oidc(self) -> CredentialsOidcGetResponse:
+        """Get the capabilities of the api.
+
+        Returns:
+            Capabilities: The capabilities of the api based off what the user provided.
+        """
+        return CredentialsOidcGetResponse(
+            providers=[
+                Provider(
+                    id=self.settings.OIDC_ORGANISATION,
+                    title="EURAC Keycloak",
+                    issuer=self.settings.OIDC_URL,
+                    # Only use standard scopes that EURAC Keycloak supports
+                    # Removed: eduperson_entitlement, eduperson_scoped_affiliation (EGI-specific)
+                    # Note: offline_access is requested by web editor for refresh tokens
+                    scopes=[
+                        "openid",
+                        "email",
+                        "profile",
+                    ],
+                    default_clients=[
+                        DefaultClient(
+                            id="openeo-platform-default-client",
+                            redirect_urls=[
+                                "https://editor.openeo.cloud/",
+                                "https://editor.openeo.org/",
+                                "http://localhost:1410/",
+                                "http://10.8.244.73:8080/",
+                                "http://localhost:8080/",
+                            ],
+                            grant_types=[
+                                GrantType.authorization_code_pkce,
+                                GrantType.urn_ietf_params_oauth_grant_type_device_code_pkce,
+                                GrantType.refresh_token,
+                            ],
+                        )
+                    ],
+                )
+            ]
+        )
+
+    def get_conformance(self) -> ConformanceGetResponse:
+        """Get the capabilities of the api.
+
+        Returns:
+            ConformanceGetResponse: The conformance classes that this Api wil of the api based off what the user provided.
+        """
+        return ConformanceGetResponse(
+            conformsTo=[
+                STACConformanceClasses.CORE.value,
+                STACConformanceClasses.COLLECTIONS.value,
+            ]
+        )
+
+    def get_file_formats(self) -> FileFormatsGetResponse:
+        """Get the supported file formats for processing input and output.
+
+        Returns:
+            FileFormatsGetResponse: The response defining the input and output formats.
+        """
+        return FileFormatsGetResponse(
+            input={_format.title: _format for _format in self.input_formats},
+            output={_format.title: _format for _format in self.output_formats},
+        )
+
+    def get_health(self):
+        """Basic health endpoint expected to return status code 200.
+
+        Returns:
+            Response: Status code 200.
+        """
+        return Response(status_code=200, content="OK")
+
+    def get_user_info(
+        self, user: User = Depends(Authenticator.validate)
+    ) -> MeGetResponse:
+        """Get the supported file formats for processing input and output.
+
+        Returns:
+            MeGetResponse: The user information for the validated user.
+        """
+        return MeGetResponse(user_id=user.user_id)
+
+    def get_well_known(self) -> WellKnownOpeneoGetResponse:
+        """Get the supported file formats for processing input and output.
+
+        Returns:
+            WellKnownOpeneoGetResponse: The api/s which are exposed at this server.
+        """
+        prefix = "https" if self.settings.API_TLS else "http"
+
+        Components = namedtuple(
+            typename="Components",
+            field_names=["scheme", "netloc", "url", "path", "query", "fragment"],
+        )
+
+        # TODO Supporting multiple versions should be possible here. But would change how we get the api version.
+        url = urlunparse(
+            Components(
+                scheme=prefix,
+                netloc=self.settings.API_DNS,
+                query=None,
+                path="",
+                url=f"/openeo/{self.settings.OPENEO_VERSION}/",
+                fragment=None,
+            )
+        )
+
+        return WellKnownOpeneoGetResponse(
+            versions=[
+                Version(
+                    api_version=self.settings.OPENEO_VERSION, url=url, production=False
+                )
+            ]
+        )
+
+    def get_udf_runtimes(self) -> UdfRuntimesGetResponse:
+        """Get the available UDF runtimes for this backend.
+
+        Returns:
+            UdfRuntimesGetResponse: The UDF runtimes available in this api deployment.
+        """
+        return {}


### PR DESCRIPTION
## Summary
- Adds `patches/` directory with patched `openeo-fastapi` library files (core.py, auth.py) that fix hardcoded EGI Check-in and JWT audience validation
- Updates API Dockerfile to apply patches after `poetry install`
- Adds `build-api.yaml` CI workflow to build and push API image to `ghcr.io/eurac-research-institute-for-eo/openeo-argoworkflows-api:latest`

## Why
We've been relying on manually built images on Docker Hub (`yuvraj1989/openeo-argoworkflows-api:eurac-custom-oidc-v*`). This moves the API image to the same ghcr.io pattern as the executor, making it reproducible and maintainable through CI.

## Result
After merge, the API image will be available at:
```
ghcr.io/eurac-research-institute-for-eo/openeo-argoworkflows-api:latest
```