### PR TITLE
feat: run_cwl executor — CWL execution via Calrissian

### DIFF
--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/cli.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/cli.py
@@ -1,46 +1,48 @@
-import click
-import fsspec
 import logging
 
+import click
+import fsspec
+
 logger = logging.getLogger(__name__)
+
 
 @click.group()
 def cli():
     """Defining group for executor CLI."""
     pass
 
+
 @click.command()
 @click.option(
-    '--process_graph',
+    "--process_graph",
     type=str,
     required=True,
-    help='OpenEO Process Graph as a JSON string.',
+    help="OpenEO Process Graph as a JSON string.",
 )
 @click.option(
-    '--user_profile',
+    "--user_profile",
     type=str,
     required=True,
-    help='Profile of the Dask Cluster to initialise.',
+    help="Profile of the Dask Cluster to initialise.",
 )
 @click.option(
-    '--dask_profile',
+    "--dask_profile",
     type=str,
     required=True,
-    help='Profile of the Dask Cluster to initialise.',
+    help="Profile of the Dask Cluster to initialise.",
 )
 def execute(process_graph, user_profile, dask_profile):
     """CLI for running the OpenEOExecutor on an OpenEO process graph."""
-    
-    import os
+
     import json
+    import os
 
-    from dask_gateway import Gateway
     import openeo_processes_dask
-    from openeo_pg_parser_networkx.graph import OpenEOProcessGraph
-
-    from openeo_argoworkflows_executor.executor import execute, _is_cwl_job
+    from dask_gateway import Gateway
+    from openeo_argoworkflows_executor.executor import _is_cwl_job, execute
     from openeo_argoworkflows_executor.models import ExecutorParameters
     from openeo_argoworkflows_executor.stac import create_stac_item
+    from openeo_pg_parser_networkx.graph import OpenEOProcessGraph
 
     logger.info(
         f"Using processes from openeo-processes-dask v{openeo_processes_dask.__version__}"
@@ -49,11 +51,13 @@ def execute(process_graph, user_profile, dask_profile):
     openeo_parameters = ExecutorParameters(
         process_graph=json.loads(process_graph),
         user_profile=json.loads(user_profile),
-        dask_profile=json.loads(dask_profile)
+        dask_profile=json.loads(dask_profile),
     )
 
     if not openeo_parameters.user_profile.OPENEO_USER_WORKSPACE.exists():
-        openeo_parameters.user_profile.OPENEO_USER_WORKSPACE.mkdir(parents=True, exist_ok=True)
+        openeo_parameters.user_profile.OPENEO_USER_WORKSPACE.mkdir(
+            parents=True, exist_ok=True
+        )
 
     if not openeo_parameters.user_profile.results_path.exists():
         openeo_parameters.user_profile.results_path.mkdir(parents=True, exist_ok=True)
@@ -61,7 +65,9 @@ def execute(process_graph, user_profile, dask_profile):
     if not openeo_parameters.user_profile.stac_path.exists():
         openeo_parameters.user_profile.stac_path.mkdir(parents=True, exist_ok=True)
 
-    os.environ["OPENEO_USER_WORKSPACE"] = str(openeo_parameters.user_profile.OPENEO_USER_WORKSPACE)
+    os.environ["OPENEO_USER_WORKSPACE"] = str(
+        openeo_parameters.user_profile.OPENEO_USER_WORKSPACE
+    )
     os.environ["OPENEO_STAC_PATH"] = str(openeo_parameters.user_profile.stac_path)
     os.environ["OPENEO_RESULTS_PATH"] = str(openeo_parameters.user_profile.results_path)
 
@@ -86,13 +92,17 @@ def execute(process_graph, user_profile, dask_profile):
 
         options.WORKER_CORES = int(openeo_parameters.dask_profile.WORKER_CORES)
         options.WORKER_MEMORY = int(openeo_parameters.dask_profile.WORKER_MEMORY)
-        options.CLUSTER_IDLE_TIMEOUT = int(openeo_parameters.dask_profile.CLUSTER_IDLE_TIMEOUT)
+        options.CLUSTER_IDLE_TIMEOUT = int(
+            openeo_parameters.dask_profile.CLUSTER_IDLE_TIMEOUT
+        )
 
         dask_cluster = gateway.new_cluster(options, shutdown_on_close=True)
 
         # We need to initiate a cluster with at least one worker, otherwise .scatter that's used in xgboost will timeout waiting for workers
         # See https://github.com/dask/distributed/issues/2941
-        dask_cluster.adapt(minimum=1, maximum=int(openeo_parameters.dask_profile.WORKER_LIMIT))
+        dask_cluster.adapt(
+            minimum=1, maximum=int(openeo_parameters.dask_profile.WORKER_LIMIT)
+        )
         client = dask_cluster.get_client()
 
     parsed_graph = OpenEOProcessGraph(pg_data=openeo_parameters.process_graph)
@@ -102,7 +112,7 @@ def execute(process_graph, user_profile, dask_profile):
     # Can't assume the same cluster is running post process graph execution due to sub workflows processing.
     # If the previous cluster was closed, check for a new one!
     if dask_cluster:
-        if dask_cluster.status == 'closed':
+        if dask_cluster.status == "closed":
             cluster_list = gateway.list_clusters()
             if cluster_list:
                 dask_cluster = gateway.connect(cluster_list[0].name)
@@ -111,6 +121,7 @@ def execute(process_graph, user_profile, dask_profile):
         dask_cluster.shutdown()
 
     import json
+
     import requests
     import xarray as xr
     from raster2stac import Raster2STAC
@@ -118,11 +129,15 @@ def execute(process_graph, user_profile, dask_profile):
     job_id = openeo_parameters.user_profile.OPENEO_JOB_ID
     results_path = str(openeo_parameters.user_profile.results_path)
     stac_path = str(openeo_parameters.user_profile.stac_path)
-    stac_api_url = os.environ.get("OPENEO_RESULTS_STAC_URL", "https://stac.openeo.eurac.edu/")
+    stac_api_url = os.environ.get(
+        "OPENEO_RESULTS_STAC_URL", "https://stac.openeo.eurac.edu/"
+    )
 
     # Collect all result files
     fs = fsspec.filesystem(protocol="file")
-    all_result_files = [f["name"] for f in fs.listdir(results_path) if not f["name"].startswith(".")]
+    all_result_files = [
+        f["name"] for f in fs.listdir(results_path) if not f["name"].startswith(".")
+    ]
     result_files = [f for f in all_result_files if f.endswith(".nc")]
     other_files = [f for f in all_result_files if not f.endswith(".nc")]
 
@@ -135,7 +150,7 @@ def execute(process_graph, user_profile, dask_profile):
             # Fix: open files explicitly and write CRS via rioxarray before passing datasets.
             datasets = []
             for filepath in result_files:
-                ds = xr.open_dataset(filepath, engine='netcdf4')
+                ds = xr.open_dataset(filepath, engine="netcdf4")
                 if ds.rio.crs is None:
                     # Read CRS from CF grid_mapping variable if present
                     # grid_mapping var may be in data_vars or coords
@@ -143,11 +158,15 @@ def execute(process_graph, user_profile, dask_profile):
                     for var in ds.data_vars:
                         gm = ds[var].attrs.get("grid_mapping")
                         if gm and gm in ds:
-                            crs_wkt = ds[gm].attrs.get("crs_wkt") or ds[gm].attrs.get("spatial_ref")
+                            crs_wkt = ds[gm].attrs.get("crs_wkt") or ds[gm].attrs.get(
+                                "spatial_ref"
+                            )
                             if crs_wkt:
                                 break
                     if crs_wkt is None and "spatial_ref" in ds:
-                        crs_wkt = ds["spatial_ref"].attrs.get("crs_wkt") or ds["spatial_ref"].attrs.get("spatial_ref")
+                        crs_wkt = ds["spatial_ref"].attrs.get("crs_wkt") or ds[
+                            "spatial_ref"
+                        ].attrs.get("spatial_ref")
                     if crs_wkt:
                         ds = ds.rio.write_crs(crs_wkt)
                 datasets.append(ds)
@@ -155,6 +174,7 @@ def execute(process_graph, user_profile, dask_profile):
             # raster2stac calls item.validate() which fetches remote JSON schemas from
             # proj.org — blocked in the executor pod (403). Disable pystac validation.
             import pystac
+
             pystac.Item.validate = lambda self: []
 
             # raster2stac expects a double-nested list when passing xarray Datasets:
@@ -186,10 +206,15 @@ def execute(process_graph, user_profile, dask_profile):
                         line = line.strip()
                         if line:
                             item_dict = json.loads(line)
-                            requests.post(f"{stac_api_url.rstrip('/')}/{job_id}/items", json=item_dict)
+                            requests.post(
+                                f"{stac_api_url.rstrip('/')}/{job_id}/items",
+                                json=item_dict,
+                            )
 
         except Exception as e:
-            logger.warning(f"STAC publishing failed for job {job_id}, results are still available: {e}")
+            logger.warning(
+                f"STAC publishing failed for job {job_id}, results are still available: {e}"
+            )
 
     # Handle non-NetCDF output files (e.g. from CWL workflows)
     # Create minimal STAC collection and items so they appear in job results
@@ -204,10 +229,12 @@ def execute(process_graph, user_profile, dask_profile):
                 stac_api_url=stac_api_url,
             )
         except Exception as e:
-            logger.warning(f"CWL STAC publishing failed for job {job_id}, results are still available: {e}")
+            logger.warning(
+                f"CWL STAC publishing failed for job {job_id}, results are still available: {e}"
+            )
 
 
 cli.add_command(execute)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()

--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/cli.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/cli.py
@@ -38,7 +38,7 @@ def execute(process_graph, user_profile, dask_profile):
     import openeo_processes_dask
     from openeo_pg_parser_networkx.graph import OpenEOProcessGraph
 
-    from openeo_argoworkflows_executor.executor import execute
+    from openeo_argoworkflows_executor.executor import execute, _is_cwl_job
     from openeo_argoworkflows_executor.models import ExecutorParameters
     from openeo_argoworkflows_executor.stac import create_stac_item
 
@@ -65,12 +65,16 @@ def execute(process_graph, user_profile, dask_profile):
     os.environ["OPENEO_STAC_PATH"] = str(openeo_parameters.user_profile.stac_path)
     os.environ["OPENEO_RESULTS_PATH"] = str(openeo_parameters.user_profile.results_path)
 
-    if openeo_parameters.dask_profile.LOCAL:
+    is_cwl = _is_cwl_job(openeo_parameters.process_graph)
+
+    # CWL jobs don't need a Dask cluster — skip cluster setup entirely
+    dask_cluster = None
+    if is_cwl:
+        logger.info("CWL job detected — skipping Dask cluster setup")
+    elif openeo_parameters.dask_profile.LOCAL:
         from dask.distributed import worker_client
 
-        dask_cluster = None
         client = worker_client()
-        pass
     else:
         gateway = Gateway(openeo_parameters.dask_profile.GATEWAY_URL)
         options = gateway.cluster_options()
@@ -116,9 +120,11 @@ def execute(process_graph, user_profile, dask_profile):
     stac_path = str(openeo_parameters.user_profile.stac_path)
     stac_api_url = os.environ.get("OPENEO_RESULTS_STAC_URL", "https://stac.openeo.eurac.edu/")
 
-    # Collect all NetCDF result files
+    # Collect all result files
     fs = fsspec.filesystem(protocol="file")
-    result_files = [f["name"] for f in fs.listdir(results_path) if f["name"].endswith(".nc")]
+    all_result_files = [f["name"] for f in fs.listdir(results_path) if not f["name"].startswith(".")]
+    result_files = [f for f in all_result_files if f.endswith(".nc")]
+    other_files = [f for f in all_result_files if not f.endswith(".nc")]
 
     if result_files:
         try:
@@ -184,6 +190,21 @@ def execute(process_graph, user_profile, dask_profile):
 
         except Exception as e:
             logger.warning(f"STAC publishing failed for job {job_id}, results are still available: {e}")
+
+    # Handle non-NetCDF output files (e.g. from CWL workflows)
+    # Create minimal STAC collection and items so they appear in job results
+    if other_files and not result_files:
+        try:
+            from openeo_argoworkflows_executor.stac_cwl import create_cwl_stac
+
+            create_cwl_stac(
+                job_id=job_id,
+                result_files=other_files,
+                stac_path=stac_path,
+                stac_api_url=stac_api_url,
+            )
+        except Exception as e:
+            logger.warning(f"CWL STAC publishing failed for job {job_id}, results are still available: {e}")
 
 
 cli.add_command(execute)

--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/executor.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/executor.py
@@ -72,13 +72,41 @@ def prepare_graphs(
 
     return sub_graphs    
 
+def _is_cwl_job(pg_data: dict) -> bool:
+    """Check if the process graph is a CWL job (contains run_cwl as a node)."""
+    for node_id, node in pg_data.items():
+        if isinstance(node, dict) and node.get("process_id") == "run_cwl":
+            return True
+    return False
+
+
+def _execute_cwl(parsed_graph: OpenEOProcessGraph, process_registry: ProcessRegistry):
+    """Execute a CWL process graph directly, bypassing tiling and Dask.
+
+    CWL jobs don't have spatial extents or load_collection nodes,
+    so the standard tiling pipeline doesn't apply. We execute the
+    process graph as a single callable.
+    """
+    logger.info("Detected CWL job — executing directly (no spatial tiling)")
+    pg_callable = parsed_graph.to_callable(
+        process_registry=process_registry,
+        results_cache={},
+    )
+    pg_callable()
+
+
 def execute(
     parsed_graph: OpenEOProcessGraph
 ):
     process_registry = ProcessRegistry(wrap_funcs=[process])
-    
+
     _register_processes_from_module(process_registry, "openeo_processes_dask")
     _register_processes_from_module(process_registry, "openeo_argoworkflows_executor.extra_processes")
+
+    # CWL jobs bypass tiling/Dask — they run Calrissian directly
+    if _is_cwl_job(parsed_graph.pg_data):
+        _execute_cwl(parsed_graph, process_registry)
+        return
 
     sub_graphs = prepare_graphs(parsed_graph)
 
@@ -87,5 +115,5 @@ def execute(
             process_registry=process_registry,
             results_cache={}
         )
-        
+
         pg_callable()

--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/executor.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/executor.py
@@ -3,15 +3,13 @@ import inspect
 import logging
 from typing import Optional
 
-from openeo_pg_parser_networkx import Process, ProcessRegistry, OpenEOProcessGraph
+from openeo_argoworkflows_executor.stac import StacGrid
+from openeo_argoworkflows_executor.utils import derive_sub_graph, get_pg_bounding_box
+from openeo_pg_parser_networkx import OpenEOProcessGraph, Process, ProcessRegistry
 from openeo_processes_dask.process_implementations.core import process
 
-from openeo_argoworkflows_executor.stac import StacGrid
-from openeo_argoworkflows_executor.utils import (
-    derive_sub_graph, get_pg_bounding_box
-)
-
 logger = logging.getLogger(__name__)
+
 
 def _register_processes_from_module(
     process_registry,
@@ -44,21 +42,16 @@ def _register_processes_from_module(
     return process_registry
 
 
-def prepare_graphs(
-    process_graph: OpenEOProcessGraph
-):
+def prepare_graphs(process_graph: OpenEOProcessGraph):
     # We get the total bounding box from the process graph
     _box = get_pg_bounding_box(process_graph.pg_data)
 
-
-    bbox = [ _box.west, _box.south, _box.east, _box.north ]
+    bbox = [_box.west, _box.south, _box.east, _box.north]
 
     tilesize = 100000
     crs = 4326
 
-    grid = StacGrid(
-        bbox, tilesize, crs
-    )
+    grid = StacGrid(bbox, tilesize, crs)
 
     # We get the cells for this given process graph
     grid.set_grid_cells()
@@ -70,7 +63,8 @@ def prepare_graphs(
             OpenEOProcessGraph(pg_data=derive_sub_graph(cell, process_graph.pg_data))
         )
 
-    return sub_graphs    
+    return sub_graphs
+
 
 def _is_cwl_job(pg_data: dict) -> bool:
     """Check if the process graph is a CWL job (contains run_cwl as a node)."""
@@ -95,13 +89,13 @@ def _execute_cwl(parsed_graph: OpenEOProcessGraph, process_registry: ProcessRegi
     pg_callable()
 
 
-def execute(
-    parsed_graph: OpenEOProcessGraph
-):
+def execute(parsed_graph: OpenEOProcessGraph):
     process_registry = ProcessRegistry(wrap_funcs=[process])
 
     _register_processes_from_module(process_registry, "openeo_processes_dask")
-    _register_processes_from_module(process_registry, "openeo_argoworkflows_executor.extra_processes")
+    _register_processes_from_module(
+        process_registry, "openeo_argoworkflows_executor.extra_processes"
+    )
 
     # CWL jobs bypass tiling/Dask — they run Calrissian directly
     if _is_cwl_job(parsed_graph.pg_data):
@@ -112,8 +106,7 @@ def execute(
 
     for graph in sub_graphs:
         pg_callable = graph.to_callable(
-            process_registry=process_registry,
-            results_cache={}
+            process_registry=process_registry, results_cache={}
         )
 
         pg_callable()

--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/__init__.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/__init__.py
@@ -1,1 +1,2 @@
+from .cwl import *
 from .io import *

--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/cwl.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/cwl.py
@@ -1,0 +1,225 @@
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+__all__ = ["run_cwl"]
+
+logger = logging.getLogger(__name__)
+
+# Default resource limits for Calrissian
+DEFAULT_MAX_RAM = "8G"
+DEFAULT_MAX_CORES = 4
+
+
+def _is_url(value: str) -> bool:
+    """Check if a string looks like a URL."""
+    parsed = urlparse(value)
+    return parsed.scheme in ("http", "https")
+
+
+def _resolve_cwl(cwl: str, work_dir: Path) -> Path:
+    """Resolve a CWL argument to a local file path.
+
+    If cwl is a URL, download it. If it's an inline string, write it to a
+    temporary file. Returns the path to the CWL file on disk.
+    """
+    if _is_url(cwl):
+        import urllib.request
+
+        cwl_path = work_dir / "workflow.cwl"
+        urllib.request.urlretrieve(cwl, str(cwl_path))
+        logger.info(f"Downloaded CWL from {cwl} to {cwl_path}")
+        return cwl_path
+
+    cwl_path = work_dir / "workflow.cwl"
+    cwl_path.write_text(cwl)
+    logger.info(f"Wrote inline CWL to {cwl_path}")
+    return cwl_path
+
+
+def _write_inputs(inputs: dict, work_dir: Path) -> Path:
+    """Write CWL job inputs to a JSON file."""
+    inputs_path = work_dir / "inputs.json"
+    inputs_path.write_text(json.dumps(inputs, indent=2))
+    return inputs_path
+
+
+def _validate_cwl(cwl_path: Path) -> dict:
+    """Validate a CWL document using cwltool.
+
+    Returns a dict with 'valid' (bool) and 'errors' (list of str).
+    """
+    result = subprocess.run(
+        ["cwltool", "--validate", str(cwl_path)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    if result.returncode == 0:
+        return {"valid": True, "errors": []}
+
+    errors = []
+    for line in (result.stderr or "").strip().splitlines():
+        if line.strip():
+            errors.append(line.strip())
+
+    return {"valid": False, "errors": errors}
+
+
+def _collect_calrissian_outputs(calrissian_outdir: Path, results_path: Path) -> list:
+    """Copy Calrissian output files to the openEO results directory.
+
+    Returns a list of destination file paths.
+    """
+    collected = []
+    if not calrissian_outdir.exists():
+        return collected
+
+    for item in calrissian_outdir.iterdir():
+        if item.is_file():
+            dest = results_path / item.name
+            shutil.copy2(str(item), str(dest))
+            collected.append(str(dest))
+            logger.info(f"Collected CWL output: {item.name} -> {dest}")
+        elif item.is_dir():
+            dest_dir = results_path / item.name
+            shutil.copytree(str(item), str(dest_dir))
+            for f in dest_dir.rglob("*"):
+                if f.is_file():
+                    collected.append(str(f))
+            logger.info(f"Collected CWL output directory: {item.name} -> {dest_dir}")
+
+    return collected
+
+
+def run_cwl(
+    cwl: str,
+    inputs: dict,
+    options: Optional[dict] = None,
+    **kwargs,
+):
+    """Execute a CWL workflow via Calrissian on Kubernetes.
+
+    This executor-side implementation overrides the processes-dask stub.
+    It resolves the CWL document, validates it, then invokes Calrissian
+    as a subprocess to run the workflow on the cluster.
+    """
+    if options is None:
+        options = {}
+
+    validate_only = options.get("validate_only", False)
+    max_ram = options.get("max_ram", DEFAULT_MAX_RAM)
+    max_cores = options.get("max_cores", DEFAULT_MAX_CORES)
+
+    results_path = os.environ.get("OPENEO_RESULTS_PATH", "/tmp/results")
+    os.makedirs(results_path, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="openeo_cwl_") as work_dir:
+        work_dir = Path(work_dir)
+
+        # Resolve CWL to a local file
+        try:
+            cwl_path = _resolve_cwl(cwl, work_dir)
+        except Exception as e:
+            raise RuntimeError(f"Failed to resolve CWL document: {e}")
+
+        # Validate CWL
+        validation = _validate_cwl(cwl_path)
+
+        if not validation["valid"]:
+            raise RuntimeError(
+                f"CWL validation failed: {'; '.join(validation['errors'])}"
+            )
+
+        if validate_only:
+            return validation
+
+        # Write inputs file
+        inputs_path = _write_inputs(inputs, work_dir)
+
+        # Set up Calrissian output directory
+        calrissian_outdir = work_dir / "output"
+        calrissian_outdir.mkdir(exist_ok=True)
+
+        calrissian_tmpdir = work_dir / "tmp"
+        calrissian_tmpdir.mkdir(exist_ok=True)
+
+        # Build Calrissian command
+        cmd = [
+            "calrissian",
+            "--max-ram",
+            str(max_ram),
+            "--max-cores",
+            str(max_cores),
+            "--outdir",
+            str(calrissian_outdir),
+            "--tmp-outdir-prefix",
+            str(calrissian_tmpdir) + "/",
+            "--stdout",
+            str(work_dir / "cwl-stdout.json"),
+            "--stderr",
+            str(work_dir / "cwl-stderr.log"),
+            str(cwl_path),
+            str(inputs_path),
+        ]
+
+        logger.info(f"Running Calrissian: {' '.join(cmd)}")
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=3600,  # 1 hour timeout for MVP
+            )
+        except subprocess.TimeoutExpired:
+            raise RuntimeError(
+                "CWL execution timed out after 3600 seconds. "
+                "Consider splitting the workflow or increasing timeout."
+            )
+
+        # Log Calrissian output
+        if result.stdout:
+            logger.info(f"Calrissian stdout:\n{result.stdout}")
+        if result.stderr:
+            logger.warning(f"Calrissian stderr:\n{result.stderr}")
+
+        if result.returncode != 0:
+            error_detail = result.stderr or result.stdout or "Unknown error"
+            # Read stderr log if available
+            stderr_log = work_dir / "cwl-stderr.log"
+            if stderr_log.exists():
+                error_detail = stderr_log.read_text()
+            raise RuntimeError(
+                f"CWL execution failed (exit code {result.returncode}): {error_detail}"
+            )
+
+        # Read Calrissian output manifest
+        stdout_json = work_dir / "cwl-stdout.json"
+        cwl_outputs = {}
+        if stdout_json.exists():
+            try:
+                cwl_outputs = json.loads(stdout_json.read_text())
+                logger.info(f"CWL outputs: {json.dumps(cwl_outputs, indent=2)}")
+            except json.JSONDecodeError:
+                logger.warning("Could not parse CWL stdout as JSON")
+
+        # Collect output files to RESULTS/
+        collected_files = _collect_calrissian_outputs(
+            calrissian_outdir, Path(results_path)
+        )
+        logger.info(f"Collected {len(collected_files)} output files to {results_path}")
+
+        # Return output metadata for downstream processing
+        return {
+            "cwl_outputs": cwl_outputs,
+            "collected_files": collected_files,
+            "status": "completed",
+        }

--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/specs/run_cwl.json
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/specs/run_cwl.json
@@ -1,0 +1,142 @@
+{
+    "id": "run_cwl",
+    "summary": "Run a CWL workflow",
+    "description": "Executes a Common Workflow Language (CWL) workflow or CommandLineTool.\n\nThe CWL document can be provided as an inline YAML/JSON string or as a URL pointing to a remote CWL file. The workflow is validated before execution. Inputs are passed as a flat key-value mapping corresponding to the CWL input parameters.\n\nOn the backend, validated CWL is executed through Calrissian on Kubernetes. Outputs are collected and exposed as standard openEO job results.\n\nThis is an MVP process. Only CWL v1.0\u20131.2 CommandLineTool and simple single-step Workflow documents are supported. Nested workflows, ScatterFeatureRequirements, and advanced CWL features are not guaranteed to work.",
+    "categories": [
+        "cubes",
+        "import"
+    ],
+    "experimental": true,
+    "parameters": [
+        {
+            "name": "cwl",
+            "description": "The CWL document to execute. Either an inline CWL string (YAML or JSON) or a URL pointing to a remote `.cwl` file (must be reachable from the backend).",
+            "schema": [
+                {
+                    "title": "Inline CWL",
+                    "description": "A CWL document provided as an inline YAML or JSON string.",
+                    "type": "string"
+                },
+                {
+                    "title": "Remote CWL URL",
+                    "description": "A URL pointing to a CWL file.",
+                    "type": "string",
+                    "format": "uri",
+                    "subtype": "uri",
+                    "pattern": "^https?://"
+                }
+            ]
+        },
+        {
+            "name": "inputs",
+            "description": "A flat key-value mapping of CWL input parameter names to their values. Keys must match the input IDs declared in the CWL document. Values can be strings, numbers, booleans, or objects (e.g. File references with `class: File` and `path` or `location`).",
+            "schema": {
+                "type": "object",
+                "title": "CWL Inputs",
+                "additionalProperties": {
+                    "description": "Any CWL-compatible input value."
+                }
+            }
+        },
+        {
+            "name": "options",
+            "description": "Optional execution flags.\n\n- `validate_only` (boolean, default `false`): If `true`, the CWL document is validated but not executed. The process returns immediately after validation.\n- `max_ram` (string, optional): Maximum RAM for concurrent CWL steps, e.g. `\"8G\"`. Defaults to backend configuration.\n- `max_cores` (integer, optional): Maximum CPU cores for concurrent CWL steps. Defaults to backend configuration.",
+            "schema": [
+                {
+                    "type": "object",
+                    "title": "Execution options",
+                    "properties": {
+                        "validate_only": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, validate the CWL document without executing it."
+                        },
+                        "max_ram": {
+                            "type": "string",
+                            "description": "Maximum RAM for concurrent CWL steps (e.g. '8G')."
+                        },
+                        "max_cores": {
+                            "type": "integer",
+                            "description": "Maximum CPU cores for concurrent CWL steps."
+                        }
+                    }
+                },
+                {
+                    "title": "No options",
+                    "description": "Use default execution settings.",
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "optional": true
+        }
+    ],
+    "returns": {
+        "description": "The CWL workflow output files, exposed as openEO job results. For `validate_only` mode, returns a validation status object.",
+        "schema": [
+            {
+                "type": "object",
+                "subtype": "datacube"
+            },
+            {
+                "type": "object",
+                "description": "Validation result when validate_only is true.",
+                "properties": {
+                    "valid": {
+                        "type": "boolean"
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "exceptions": {
+        "CwlInvalidDocument": {
+            "message": "The provided CWL document is not valid."
+        },
+        "CwlExecutionFailed": {
+            "message": "The CWL workflow execution failed."
+        },
+        "CwlInputMismatch": {
+            "message": "The provided inputs do not match the CWL document's declared input parameters."
+        }
+    },
+    "examples": [
+        {
+            "title": "Run a simple CWL CommandLineTool from URL",
+            "arguments": {
+                "cwl": "https://raw.githubusercontent.com/common-workflow-language/common-workflow-language/main/v1.0/v1.0/echo-tool.cwl",
+                "inputs": {
+                    "message": "Hello from openEO"
+                }
+            }
+        },
+        {
+            "title": "Validate a CWL document without running it",
+            "arguments": {
+                "cwl": "https://example.com/workflow.cwl",
+                "inputs": {},
+                "options": {
+                    "validate_only": true
+                }
+            }
+        }
+    ],
+    "links": [
+        {
+            "href": "https://www.commonwl.org/",
+            "rel": "about",
+            "title": "Common Workflow Language specification"
+        },
+        {
+            "href": "https://github.com/Duke-GCB/calrissian",
+            "rel": "about",
+            "title": "Calrissian: CWL runner for Kubernetes"
+        }
+    ]
+}

--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/stac_cwl.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/stac_cwl.py
@@ -1,0 +1,135 @@
+"""Minimal STAC generation for CWL workflow output files.
+
+CWL workflows can produce arbitrary file types (not just NetCDF).
+This module creates simple STAC collections and items for any output
+files so they appear in the openEO job results endpoint.
+"""
+
+import json
+import logging
+import mimetypes
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Common media types for CWL outputs
+MEDIA_TYPES = {
+    ".tif": "image/tiff; application=geotiff",
+    ".tiff": "image/tiff; application=geotiff",
+    ".nc": "application/x-netcdf",
+    ".json": "application/json",
+    ".geojson": "application/geo+json",
+    ".csv": "text/csv",
+    ".txt": "text/plain",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".xml": "application/xml",
+    ".gml": "application/gml+xml",
+    ".zip": "application/zip",
+    ".tar": "application/x-tar",
+    ".gz": "application/gzip",
+}
+
+
+def _get_media_type(filepath: str) -> str:
+    """Get the media type for a file based on its extension."""
+    ext = Path(filepath).suffix.lower()
+    if ext in MEDIA_TYPES:
+        return MEDIA_TYPES[ext]
+    guessed, _ = mimetypes.guess_type(filepath)
+    return guessed or "application/octet-stream"
+
+
+def create_cwl_stac(
+    job_id: str,
+    result_files: list,
+    stac_path: str,
+    stac_api_url: str,
+):
+    """Create a STAC collection and items for CWL output files.
+
+    Parameters
+    ----------
+    job_id : str
+        The openEO job ID, used as the STAC collection ID.
+    result_files : list
+        List of absolute file paths to CWL output files.
+    stac_path : str
+        Directory to write STAC JSON files.
+    stac_api_url : str
+        URL of the STAC API for publishing.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+
+    # Build STAC collection
+    collection = {
+        "type": "Collection",
+        "id": job_id,
+        "stac_version": "1.0.0",
+        "description": f"CWL workflow results for openEO job {job_id}",
+        "links": [],
+        "title": f"Job {job_id} results",
+        "extent": {
+            "spatial": {"bbox": [[-180, -90, 180, 90]]},
+            "temporal": {"interval": [[now, None]]},
+        },
+        "license": "proprietary",
+    }
+
+    # Build STAC items — one per output file
+    items = []
+    for filepath in result_files:
+        filename = Path(filepath).name
+        file_size = os.path.getsize(filepath) if os.path.exists(filepath) else 0
+        item_id = Path(filepath).stem
+
+        item = {
+            "type": "Feature",
+            "stac_version": "1.0.0",
+            "id": item_id,
+            "geometry": None,
+            "bbox": None,
+            "properties": {
+                "datetime": now,
+            },
+            "links": [],
+            "assets": {
+                filename: {
+                    "href": filepath,
+                    "type": _get_media_type(filepath),
+                    "title": filename,
+                    "file:size": file_size,
+                    "roles": ["data"],
+                }
+            },
+            "collection": job_id,
+        }
+        items.append(item)
+
+    # Write collection JSON
+    os.makedirs(stac_path, exist_ok=True)
+    collection_file = os.path.join(stac_path, f"{job_id}.json")
+    with open(collection_file, "w") as f:
+        json.dump(collection, f, indent=2)
+    logger.info(f"Wrote CWL STAC collection to {collection_file}")
+
+    # Write items as inline_items.csv (same format as raster2stac)
+    items_file = os.path.join(stac_path, "inline_items.csv")
+    with open(items_file, "w") as f:
+        for item in items:
+            f.write(json.dumps(item) + "\n")
+    logger.info(f"Wrote {len(items)} CWL STAC items to {items_file}")
+
+    # POST to STAC API
+    try:
+        requests.post(stac_api_url, json=collection)
+        for item in items:
+            requests.post(f"{stac_api_url.rstrip('/')}/{job_id}/items", json=item)
+        logger.info(f"Published CWL STAC to {stac_api_url}")
+    except Exception as e:
+        logger.warning(f"Failed to publish CWL STAC to API: {e}")

--- a/openeo_argoworkflows/executor/pyproject.toml
+++ b/openeo_argoworkflows/executor/pyproject.toml
@@ -18,6 +18,8 @@ odc-stac = ">=0.3.3,<1"
 stactools = "^0.4.8"
 rioxarray = ">=0.15.1,<1"
 netCDF4 = "<=1.6.5"
+calrissian = ">=0.16.0"
+cwltool = ">=3.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"


### PR DESCRIPTION
## Summary
Implements the CWL execution bridge for the `run_cwl` process (issue #24, epic #23).

- **`extra_processes/process_implementations/cwl.py`** — Executor-side `run_cwl` override that resolves CWL (inline/URL), validates via `cwltool --validate`, and invokes Calrissian as a subprocess. Collects outputs to the workspace RESULTS/ directory.
- **`executor.py`** — Detects CWL jobs in the process graph and routes them to a direct execution path (bypasses spatial tiling and Dask, which don't apply to CWL).
- **`cli.py`** — Skips Dask cluster setup for CWL jobs. Handles non-NetCDF output files in the post-execution STAC pipeline.
- **`stac_cwl.py`** — Minimal STAC collection/item generation for arbitrary CWL output files (not just NetCDF).
- **`pyproject.toml`** — Adds `calrissian` and `cwltool` dependencies.
- **`run_cwl.json`** spec copied from openeo-processes-dask PR #6.

## Execution flow
```
POST /jobs (process graph with run_cwl)
→ executor detects run_cwl → skips Dask/tiling
→ resolves CWL document → validates → invokes Calrissian subprocess
→ Calrissian creates K8s pods for CWL steps → outputs to RESULTS/
→ STAC items generated → published to STAC API
→ job status → finished
```

## Infrastructure prerequisites (not in this PR)
- Calrissian + cwltool installed in executor image (Dockerfile update)
- RBAC: executor service account needs pod create/delete/watch permissions
- RWX PVC for Calrissian tmp/output (or reuse existing workspace PVC)

## Test plan
- [ ] Unit test: `_is_cwl_job()` correctly detects CWL process graphs
- [ ] Integration test: end-to-end with a simple CWL CommandLineTool (issue #25)
- [ ] Verify non-CWL jobs are unaffected (standard tiling/Dask path)

Closes #24