### PR TITLE
feat: CWL golden-path test and developer documentation

### DIFF
--- a/examples/cwl/README.md
+++ b/examples/cwl/README.md
@@ -1,0 +1,208 @@
+# run_cwl MVP — Developer Guide
+
+## Overview
+
+The `run_cwl` process executes CWL (Common Workflow Language) workflows
+through the openEO backend. CWL documents are validated with `cwltool`
+and executed via Calrissian on Kubernetes.
+
+## Quick Start
+
+### 1. Validate locally with cwltool
+
+```bash
+# Install cwltool
+pip install cwltool
+
+# Validate the golden-path workflow
+cwltool --validate examples/cwl/echo-tool.cwl
+
+# Run locally (requires Docker)
+cwltool examples/cwl/echo-tool.cwl examples/cwl/echo-inputs.json
+```
+
+Expected output: a file `output.txt` containing `Hello from openEO run_cwl MVP`.
+
+### 2. Submit via openEO API
+
+```bash
+# Create a job with the run_cwl process graph
+curl -X POST https://<backend>/jobs \
+  -H "Authorization: Bearer oidc/eurac/<token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "process": {
+      "process_graph": {
+        "run1": {
+          "process_id": "run_cwl",
+          "arguments": {
+            "cwl": "https://raw.githubusercontent.com/Eurac-Research-Institute-for-EO/openeo-argoworkflows/main/examples/cwl/echo-tool.cwl",
+            "inputs": {
+              "message": "Hello from openEO"
+            }
+          },
+          "result": true
+        }
+      }
+    }
+  }'
+
+# Start the job
+curl -X POST https://<backend>/jobs/<job-id>/results \
+  -H "Authorization: Bearer oidc/eurac/<token>"
+
+# Check status
+curl https://<backend>/jobs/<job-id> \
+  -H "Authorization: Bearer oidc/eurac/<token>"
+
+# Download results
+curl https://<backend>/jobs/<job-id>/results \
+  -H "Authorization: Bearer oidc/eurac/<token>"
+```
+
+### 3. Submit via Python client
+
+```python
+import openeo
+
+conn = openeo.connect("https://<backend>")
+conn.authenticate_oidc()
+
+job = conn.create_job(
+    process_graph={
+        "run1": {
+            "process_id": "run_cwl",
+            "arguments": {
+                "cwl": "https://raw.githubusercontent.com/Eurac-Research-Institute-for-EO/openeo-argoworkflows/main/examples/cwl/echo-tool.cwl",
+                "inputs": {
+                    "message": "Hello from openEO"
+                }
+            },
+            "result": True
+        }
+    }
+)
+job.start()
+job.logs()
+results = job.get_results()
+results.download_files("./output/")
+```
+
+## Process Graph Format
+
+```json
+{
+  "run1": {
+    "process_id": "run_cwl",
+    "arguments": {
+      "cwl": "<inline CWL string or URL>",
+      "inputs": {
+        "<cwl_input_name>": "<value>"
+      },
+      "options": {
+        "validate_only": false,
+        "max_ram": "8G",
+        "max_cores": 4
+      }
+    },
+    "result": true
+  }
+}
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `cwl` | string | yes | Inline CWL document (YAML/JSON) or URL to a `.cwl` file |
+| `inputs` | object | yes | Key-value mapping of CWL input parameter names to values |
+| `options` | object | no | Execution options (see below) |
+
+### Options
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `validate_only` | boolean | `false` | Validate CWL without executing |
+| `max_ram` | string | `"8G"` | Max RAM for Calrissian (e.g. `"16G"`) |
+| `max_cores` | integer | `4` | Max CPU cores for Calrissian |
+
+## Architecture
+
+```
+User submits openEO job with run_cwl process
+    │
+    ▼
+API creates job → PostgreSQL → Redis queue
+    │
+    ▼
+Executor pod starts (Argo Workflow)
+    │
+    ├─ Detects run_cwl → skips Dask cluster setup
+    │
+    ▼
+Resolves CWL (download URL or write inline)
+    │
+    ▼
+Validates with cwltool --validate
+    │
+    ▼
+Invokes Calrissian subprocess
+    │   └─ Calrissian creates K8s pods for each CWL step
+    │
+    ▼
+Collects outputs → copies to workspace RESULTS/
+    │
+    ▼
+Generates STAC collection + items
+    │
+    ▼
+Job status → finished
+```
+
+## Debugging
+
+### Check executor logs
+
+```bash
+# Find the Argo workflow pod
+kubectl get pods -n openeo -l OPENEO_JOB_ID=<job-id>
+
+# Check executor logs
+kubectl logs -n openeo <pod-name> -c main
+
+# Look for CWL-specific log lines:
+# "CWL job detected — skipping Dask cluster setup"
+# "Running Calrissian: ..."
+# "Calrissian stderr: ..."
+# "Collected N output files to ..."
+```
+
+### Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `CWL validation failed` | Invalid CWL document | Validate locally first: `cwltool --validate your.cwl` |
+| `CWL execution failed (exit code 1)` | Calrissian step pod failed | Check Calrissian stderr in executor logs |
+| `Failed to resolve CWL document` | URL unreachable or invalid inline CWL | Verify URL is accessible from the cluster |
+| `CWL execution timed out` | Workflow exceeds 1-hour timeout | Simplify workflow or split into smaller steps |
+
+## Infrastructure Requirements
+
+For cluster execution, the following must be configured:
+
+1. **Executor image**: Must include `calrissian` and `cwltool` packages
+2. **RBAC**: Executor service account needs pod create/delete/watch permissions
+   (Calrissian creates pods for each CWL step)
+3. **Storage**: RWX PVC for Calrissian working directories
+
+## Known Limitations (MVP)
+
+- **CWL v1.0–1.2 only**: Only `CommandLineTool` and simple single-step `Workflow` are tested
+- **No ScatterFeatureRequirement**: Parallel scatter is not supported
+- **No SubworkflowFeatureRequirement**: Nested workflows are not tested
+- **No private registries**: Docker images must be publicly accessible
+- **No secrets**: CWL steps cannot access Kubernetes secrets
+- **1-hour timeout**: Long-running workflows will be terminated
+- **File outputs only**: CWL outputs must be `File` type (not `Directory`)
+- **No CWL → openEO data cube bridging**: CWL outputs are raw files, not xarray cubes
+- **STAC for non-NetCDF is minimal**: Only file metadata (no spatial/temporal extent)

--- a/examples/cwl/echo-inputs.json
+++ b/examples/cwl/echo-inputs.json
@@ -1,0 +1,3 @@
+{
+  "message": "Hello from openEO run_cwl MVP"
+}

--- a/examples/cwl/echo-tool.cwl
+++ b/examples/cwl/echo-tool.cwl
@@ -1,0 +1,32 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.2
+class: CommandLineTool
+
+label: "Echo message to file"
+doc: |
+  Golden-path CWL CommandLineTool for testing the openEO run_cwl process.
+  Writes a message to an output file. Uses only standard POSIX tools
+  (sh, echo) so it runs in any Docker image including the default CWL
+  node container.
+
+baseCommand: ["sh", "-c"]
+
+requirements:
+  DockerRequirement:
+    dockerPull: "alpine:3.19"
+
+inputs:
+  message:
+    type: string
+    doc: "The message to write to the output file."
+    inputBinding:
+      position: 1
+      valueFrom: |
+        echo '$(self)' > output.txt
+
+outputs:
+  output_file:
+    type: File
+    outputBinding:
+      glob: "output.txt"
+    doc: "The file containing the echoed message."

--- a/examples/cwl/process-graph.json
+++ b/examples/cwl/process-graph.json
@@ -1,0 +1,12 @@
+{
+  "run1": {
+    "process_id": "run_cwl",
+    "arguments": {
+      "cwl": "https://raw.githubusercontent.com/Eurac-Research-Institute-for-EO/openeo-argoworkflows/main/examples/cwl/echo-tool.cwl",
+      "inputs": {
+        "message": "Hello from openEO run_cwl MVP"
+      }
+    },
+    "result": true
+  }
+}

--- a/openeo_argoworkflows/executor/tests/test_cwl.py
+++ b/openeo_argoworkflows/executor/tests/test_cwl.py
@@ -1,0 +1,121 @@
+"""Tests for CWL process detection and STAC generation."""
+
+import json
+import os
+import tempfile
+
+from openeo_argoworkflows_executor.executor import _is_cwl_job
+from openeo_argoworkflows_executor.stac_cwl import _get_media_type, create_cwl_stac
+
+
+class TestIsCwlJob:
+    """Tests for _is_cwl_job detection logic."""
+
+    def test_detects_run_cwl_process(self):
+        pg = {
+            "run1": {
+                "process_id": "run_cwl",
+                "arguments": {
+                    "cwl": "https://example.com/workflow.cwl",
+                    "inputs": {"message": "hello"},
+                },
+                "result": True,
+            }
+        }
+        assert _is_cwl_job(pg) is True
+
+    def test_rejects_standard_process_graph(self):
+        pg = {
+            "load1": {
+                "process_id": "load_collection",
+                "arguments": {"id": "S2", "spatial_extent": {}},
+            },
+            "save1": {
+                "process_id": "save_result",
+                "arguments": {"data": {"from_node": "load1"}, "format": "netcdf"},
+                "result": True,
+            },
+        }
+        assert _is_cwl_job(pg) is False
+
+    def test_rejects_empty_process_graph(self):
+        assert _is_cwl_job({}) is False
+
+    def test_detects_cwl_in_mixed_graph(self):
+        pg = {
+            "load1": {
+                "process_id": "load_collection",
+                "arguments": {"id": "S2"},
+            },
+            "cwl1": {
+                "process_id": "run_cwl",
+                "arguments": {"cwl": "inline cwl", "inputs": {}},
+                "result": True,
+            },
+        }
+        assert _is_cwl_job(pg) is True
+
+
+class TestGetMediaType:
+    """Tests for media type detection."""
+
+    def test_geotiff(self):
+        assert "geotiff" in _get_media_type("output.tif")
+
+    def test_netcdf(self):
+        assert _get_media_type("data.nc") == "application/x-netcdf"
+
+    def test_json(self):
+        assert _get_media_type("result.json") == "application/json"
+
+    def test_csv(self):
+        assert _get_media_type("table.csv") == "text/csv"
+
+    def test_unknown(self):
+        assert _get_media_type("data.xyz123") == "application/octet-stream"
+
+
+class TestCreateCwlStac:
+    """Tests for CWL STAC generation."""
+
+    def test_creates_collection_and_items(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create fake result files
+            results_dir = os.path.join(tmpdir, "results")
+            os.makedirs(results_dir)
+            file1 = os.path.join(results_dir, "output.txt")
+            file2 = os.path.join(results_dir, "data.json")
+            with open(file1, "w") as f:
+                f.write("hello")
+            with open(file2, "w") as f:
+                json.dump({"key": "value"}, f)
+
+            stac_path = os.path.join(tmpdir, "stac")
+
+            # Don't actually POST to STAC API
+            create_cwl_stac(
+                job_id="test-job-123",
+                result_files=[file1, file2],
+                stac_path=stac_path,
+                stac_api_url="http://localhost:9999/",
+            )
+
+            # Check collection was created
+            collection_file = os.path.join(stac_path, "test-job-123.json")
+            assert os.path.exists(collection_file)
+            with open(collection_file) as f:
+                collection = json.load(f)
+            assert collection["id"] == "test-job-123"
+            assert collection["type"] == "Collection"
+
+            # Check items were created
+            items_file = os.path.join(stac_path, "inline_items.csv")
+            assert os.path.exists(items_file)
+            with open(items_file) as f:
+                lines = [line.strip() for line in f if line.strip()]
+            assert len(lines) == 2
+
+            item1 = json.loads(lines[0])
+            assert item1["type"] == "Feature"
+            assert item1["collection"] == "test-job-123"
+            assert "output.txt" in item1["assets"]


### PR DESCRIPTION
## Summary
Adds the golden-path test workflow and MVP developer documentation for `run_cwl` (issue #25, epic #23).

- **`examples/cwl/echo-tool.cwl`** — Simple CWL CommandLineTool: writes a message to `output.txt` using `alpine:3.19`. Validates locally with `cwltool` and runs on Calrissian.
- **`examples/cwl/echo-inputs.json`** — Input payload for the golden workflow.
- **`examples/cwl/process-graph.json`** — openEO process graph that invokes `run_cwl` with the echo tool.
- **`examples/cwl/README.md`** — Developer guide: local validation, API/Python submission, architecture diagram, debugging tips, known limitations.
- **`tests/test_cwl.py`** — Unit tests for `_is_cwl_job()` detection, `_get_media_type()`, and `create_cwl_stac()` STAC generation.

## Test plan
- [ ] `cwltool --validate examples/cwl/echo-tool.cwl` passes
- [ ] `cwltool examples/cwl/echo-tool.cwl examples/cwl/echo-inputs.json` produces `output.txt`
- [ ] Unit tests pass: `pytest openeo_argoworkflows/executor/tests/test_cwl.py`
- [ ] End-to-end cluster test (after Calrissian + RBAC setup in issue #25 follow-up)

Closes #25