### PR TITLE
feat: add calrissian/cwltool to executor image

### DIFF
--- a/.github/workflows/build-executor.yaml
+++ b/.github/workflows/build-executor.yaml
@@ -6,9 +6,8 @@ on:
       - main
     paths:
       - 'Dockerfile.executor'
-      - 'openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/io.py'
-      - 'openeo_argoworkflows/executor/openeo_argoworkflows_executor/stac.py'
-      - 'openeo_argoworkflows/executor/openeo_argoworkflows_executor/cli.py'
+      - 'openeo_argoworkflows/executor/openeo_argoworkflows_executor/**'
+      - 'openeo_argoworkflows/executor/pyproject.toml'
   workflow_dispatch:
 
 env:

--- a/Dockerfile.executor
+++ b/Dockerfile.executor
@@ -25,6 +25,9 @@ RUN $VIRTUAL_ENV/bin/pip install boto3 dask fsspec h5netcdf h5py kerchunk netcdf
         pandas pydantic rasterio rio-stac rioxarray s3fs ujson xarray zarr requests && \
     $VIRTUAL_ENV/bin/pip install --no-deps raster2stac
 
+# Install CWL execution dependencies (calrissian for K8s CWL runner, cwltool for validation)
+RUN $VIRTUAL_ENV/bin/pip install calrissian cwltool
+
 ########################################################################################################################
 FROM python:3.11-slim-bookworm AS prod
 


### PR DESCRIPTION
## Summary
Adds CWL runtime dependencies to the executor Docker image and widens CI trigger paths.

- **Dockerfile.executor**: `pip install calrissian cwltool` after raster2stac install
- **build-executor.yaml**: widen path triggers from 3 specific files to all executor source + pyproject.toml

## Why
PR #26 added calrissian/cwltool to `pyproject.toml` but the poetry.lock wasn't regenerated. This adds them via direct pip install in the Dockerfile as a pragmatic fix. The CI path filter was also too narrow — it missed new files like `cwl.py` and `stac_cwl.py`.

## After merge
1. CI will auto-build and push new executor image to ghcr.io
2. RBAC update needed on cluster (separate kubectl step — Calrissian needs pod create/delete)
3. Restart deployment to pull new image