### PR TITLE
fix(ci): add poetry.lock to executor build triggers

### DIFF
--- a/.github/workflows/build-executor.yaml
+++ b/.github/workflows/build-executor.yaml
@@ -8,6 +8,7 @@ on:
       - 'Dockerfile.executor'
       - 'openeo_argoworkflows/executor/openeo_argoworkflows_executor/**'
       - 'openeo_argoworkflows/executor/pyproject.toml'
+      - 'openeo_argoworkflows/executor/poetry.lock'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
- Adds `openeo_argoworkflows/executor/poetry.lock` to the executor image build CI path triggers
- Prevents situations where a lock file update (like PR #29) doesn't trigger a rebuild

## Test plan
- [ ] Future poetry.lock-only changes trigger the executor build workflow