### PR TITLE
fix: inject CALRISSIAN_POD_NAME via Downward API into executor pod

### DIFF
--- a/openeo_argoworkflows/api/openeo_argoworkflows_api/workflows.py
+++ b/openeo_argoworkflows/api/openeo_argoworkflows_api/workflows.py
@@ -1,7 +1,10 @@
 import json
 
 from hera.workflows import Steps, Workflow, WorkflowsService, Step, Env
-from hera.workflows.models import Template, Container, Metadata, PersistentVolumeClaimVolumeSource, Volume, VolumeMount
+from hera.workflows.models import (
+    Template, Container, Metadata, PersistentVolumeClaimVolumeSource,
+    Volume, VolumeMount, EnvVar, EnvVarSource, ObjectFieldSelector,
+)
 
 from openeo_argoworkflows_api.settings import ExtendedAppSettings
 
@@ -38,7 +41,14 @@ def executor_workflow(service: WorkflowsService, process_graph: dict, dask_profi
                     name="executor",
                     container=Container(
                         env=[
-                            Env(name="STAC_API_URL", value=str(settings.STAC_API_URL))
+                            Env(name="STAC_API_URL", value=str(settings.STAC_API_URL)),
+                            # Calrissian requires its own pod name to orchestrate CWL step pods.
+                            EnvVar(
+                                name="CALRISSIAN_POD_NAME",
+                                value_from=EnvVarSource(
+                                    field_ref=ObjectFieldSelector(field_path="metadata.name")
+                                ),
+                            ),
                         ],
                         image=settings.OPENEO_EXECUTOR_IMAGE,
                         command=["openeo_executor"],


### PR DESCRIPTION
## Problem

Running `run_cwl` jobs fails immediately with:

```
ERROR Unhandled error: Missing required environment variable $CALRISSIAN_POD_NAME
```

Calrissian uses this env var to identify itself as the orchestrating pod when creating and monitoring CWL step pods via the Kubernetes API.

## Fix

Inject `CALRISSIAN_POD_NAME` into the executor container spec in `workflows.py` using the Kubernetes Downward API (`fieldRef: metadata.name`), so the pod automatically receives its own name at runtime — no hardcoding required.

## Testing

Confirmed via e2e test (echo-tool.cwl golden path): job no longer fails at Calrissian startup after this fix.

Part of epic #23 — CWL MVP.