### PR TITLE
fix: use PVC-backed workspace for Calrissian work dirs

### DIFF
--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/cwl.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/cwl.py
@@ -121,7 +121,16 @@ def run_cwl(
     results_path = os.environ.get("OPENEO_RESULTS_PATH", "/tmp/results")
     os.makedirs(results_path, exist_ok=True)
 
-    with tempfile.TemporaryDirectory(prefix="openeo_cwl_") as work_dir:
+    # Calrissian requires working directories to be on a PVC (not emptyDir).
+    # Use the workspace PVC path for CWL working dirs so Calrissian can
+    # share files between the orchestrator and CWL step pods.
+    workspace_root = os.environ.get("OPENEO_USER_WORKSPACE", results_path)
+    cwl_work_base = Path(workspace_root) / "_cwl_work"
+    cwl_work_base.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(
+        prefix="openeo_cwl_", dir=str(cwl_work_base)
+    ) as work_dir:
         work_dir = Path(work_dir)
 
         # Resolve CWL to a local file
@@ -144,7 +153,7 @@ def run_cwl(
         # Write inputs file
         inputs_path = _write_inputs(inputs, work_dir)
 
-        # Set up Calrissian output directory
+        # Set up Calrissian output and tmp dirs on the PVC
         calrissian_outdir = work_dir / "output"
         calrissian_outdir.mkdir(exist_ok=True)
 


### PR DESCRIPTION
## Summary
- Move Calrissian working directories from `/tmp` (emptyDir) to the workspace PVC path (`OPENEO_USER_WORKSPACE/_cwl_work/`)
- Calrissian requires `--outdir` and `--tmp-outdir-prefix` to be on a persistent volume so it can share files with CWL step pods it spawns

## Root cause
Calrissian validates that its output/tmp directories are on a PVC mount. The executor pod's `/tmp` is an emptyDir volume, which Calrissian rejects with: `Could not find a persistent volume mounted for /tmp/...`

## Test plan
- [ ] CWL echo-tool job gets past the PVC check and Calrissian spawns step pods