### PR TITLE
fix: Calrissian PVC lookup for Argo multi-container pods

### DIFF
--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/cwl.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/cwl.py
@@ -167,6 +167,27 @@ def run_cwl(
             os.environ["CALRISSIAN_POD_NAME"] = socket.gethostname()
             logger.info(f"Set CALRISSIAN_POD_NAME={os.environ['CALRISSIAN_POD_NAME']}")
 
+        # Calrissian's KubernetesPodVolumeInspector.get_first_container()
+        # returns containers[0], which in Argo Workflow pods is the 'wait'
+        # sidecar — not the 'main' executor container. Patch it to find
+        # the container named 'main' so PVC mount paths are resolved
+        # correctly.
+        try:
+            from calrissian.job import KubernetesPodVolumeInspector
+
+            _orig = KubernetesPodVolumeInspector.get_first_container
+
+            def _get_main_container(self):
+                for c in self.pod.spec.containers:
+                    if c.name == "main":
+                        return c
+                return _orig(self)
+
+            KubernetesPodVolumeInspector.get_first_container = _get_main_container
+            logger.info("Patched Calrissian to use 'main' container for PVC resolution")
+        except Exception as e:
+            logger.warning(f"Could not patch Calrissian PVC inspector: {e}")
+
         # Build Calrissian command
         cmd = [
             "calrissian",


### PR DESCRIPTION
## Summary
- Monkey-patch Calrissian's `KubernetesPodVolumeInspector.get_first_container()` to return the `main` container instead of `containers[0]`
- In Argo Workflow pods, `containers[0]` is the `wait` sidecar (PVC at `/mainctrfs/user_workspaces`) while the executor runs in `main` (PVC at `/user_workspaces`). Calrissian was checking the wrong container's mounts.

## Root cause
Calrissian hardcodes `pod.spec.containers[0]` to find PVC mounts. Argo Workflows injects a `wait` sidecar as the first container, which mounts the PVC at a different path than the `main` executor container.

## Test plan
- [ ] CWL echo-tool job gets past PVC resolution and Calrissian spawns step pods