### PR TITLE
fix(api): return structured log entries from /jobs/{id}/logs

### DIFF
--- a/openeo_argoworkflows/api/openeo_argoworkflows_api/jobs.py
+++ b/openeo_argoworkflows/api/openeo_argoworkflows_api/jobs.py
@@ -279,11 +279,18 @@ class ArgoJobsRegister(JobsRegister):
         logs = []
         if resp.status_code == 200:
             raw_logs = resp.content.decode("utf8").split("\n")
-            logs = [
-                json.loads(log)["result"]["content"]
-                for log in raw_logs
-                if log != "" and "content" in json.loads(log)["result"].keys()
-            ]
+            for idx, log in enumerate(raw_logs):
+                if log == "":
+                    continue
+                parsed = json.loads(log)
+                if "content" not in parsed.get("result", {}).keys():
+                    continue
+                content = parsed["result"]["content"]
+                logs.append({
+                    "id": str(idx),
+                    "level": "info",
+                    "message": content,
+                })
 
         return JobsGetLogsResponse(
                 logs=logs,


### PR DESCRIPTION
## Summary
- The `/jobs/{id}/logs` endpoint was returning plain strings instead of structured objects
- The OpenEO API spec requires each log entry to have `id`, `level`, and `message` fields
- Web Editor crashes with "cannot read properties of undefined (reading id)" because it expects objects

## Changes
- Wrap each log line as `{"id": "<index>", "level": "info", "message": "<content>"}` 

## Test plan
- [ ] Open Web Editor, run a job, check logs tab loads without error
- [ ] Verify `GET /jobs/{id}/logs` returns structured log entries