### PR TITLE
fix(executor): write CWL STAC items to items/ directory

### DIFF
--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/stac_cwl.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/stac_cwl.py
@@ -118,12 +118,15 @@ def create_cwl_stac(
         json.dump(collection, f, indent=2)
     logger.info(f"Wrote CWL STAC collection to {collection_file}")
 
-    # Write items as inline_items.csv (same format as raster2stac)
-    items_file = os.path.join(stac_path, "inline_items.csv")
-    with open(items_file, "w") as f:
-        for item in items:
-            f.write(json.dumps(item) + "\n")
-    logger.info(f"Wrote {len(items)} CWL STAC items to {items_file}")
+    # Write individual item JSON files to items/ directory
+    # The API's get_results() reads STAC/items/*.json to build signed asset URLs
+    items_dir = os.path.join(stac_path, "items")
+    os.makedirs(items_dir, exist_ok=True)
+    for item in items:
+        item_file = os.path.join(items_dir, f"{item['id']}.json")
+        with open(item_file, "w") as f:
+            json.dump(item, f, indent=2)
+    logger.info(f"Wrote {len(items)} CWL STAC items to {items_dir}")
 
     # POST to STAC API
     try:


### PR DESCRIPTION
## Summary
- CWL job results return an empty STAC collection with no downloadable assets
- Root cause: `stac_cwl.py` wrote items to `inline_items.csv`, but the API reads from `STAC/items/*.json`
- Fix: write each STAC item as an individual JSON file in `STAC/items/`

## Test plan
- [ ] Merge and wait for executor image build
- [ ] Run a new CWL job (echo-tool.cwl)
- [ ] Verify `GET /jobs/{id}/results` returns assets with signed download URLs
- [ ] Download output file and verify content

Closes #39