### PR TITLE
fix(api): support common file types in /files download

### DIFF
--- a/openeo_argoworkflows/api/openeo_argoworkflows_api/files.py
+++ b/openeo_argoworkflows/api/openeo_argoworkflows_api/files.py
@@ -136,14 +136,21 @@ class ArgoFileRegister(FilesRegister):
         extention = splitext(absolute_path)[1]
         mime_types = {
             ".tif": "image/tiff; application=geotiff; profile=cloud-optimized",
+            ".tiff": "image/tiff; application=geotiff",
             ".nc": "application/netcdf",
-            ".json": "application/json"
+            ".json": "application/json",
+            ".geojson": "application/geo+json",
+            ".csv": "text/csv",
+            ".txt": "text/plain",
+            ".png": "image/png",
+            ".jpg": "image/jpeg",
+            ".jpeg": "image/jpeg",
+            ".xml": "application/xml",
+            ".zip": "application/zip",
+            ".gz": "application/gzip",
         }
 
-        try:
-            mime_type = mime_types[extention]
-        except ValueError as e:
-            raise HTTPException(status_code=400, detail=e.args[0])
+        mime_type = mime_types.get(extention, "application/octet-stream")
 
         range_request = request.headers.get("Range")
         fsize = fs.size(absolute_path)


### PR DESCRIPTION
## Summary
- Expanded `mime_types` dict in `files.py:download_file()` to include common CWL output types (`.txt`, `.csv`, `.png`, `.jpg`, `.xml`, `.zip`, `.gz`, `.geojson`, `.tiff`)
- Replaced `dict[key]` + `except ValueError` with `dict.get(ext, "application/octet-stream")` — the old code raised `KeyError` (not `ValueError`) for unknown extensions, causing unhandled 500 errors
- Any unknown extension now returns `application/octet-stream` instead of crashing

## Root cause
CWL jobs produce `.txt` files. When the Web Editor tried to download via signed `/files/` URL, the server crashed with `KeyError` → 500.

Closes #41