### PR TITLE
fix(executor): add Node.js for CWL JavaScript expressions

### DIFF
--- a/Dockerfile.executor
+++ b/Dockerfile.executor
@@ -39,7 +39,7 @@ WORKDIR /opt/openeo_argoworkflows_executor
 COPY --from=base --chown=${USER_ID}:${GROUP_ID} /opt/openeo_argoworkflows_executor/.venv /opt/openeo_argoworkflows_executor/.venv
 COPY --chown=${USER_ID}:${GROUP_ID} ./openeo_argoworkflows/executor/openeo_argoworkflows_executor /opt/openeo_argoworkflows_executor
 
-RUN apt-get update && apt-get install -y libexpat1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libexpat1 nodejs && rm -rf /var/lib/apt/lists/*
 
 RUN ln -sf /usr/local/bin/python /opt/openeo_argoworkflows_executor/.venv/bin/python \
     && ln -sf /usr/local/bin/python3 /opt/openeo_argoworkflows_executor/.venv/bin/python3 \


### PR DESCRIPTION
## Summary
- Added `nodejs` to the executor image's apt-get install
- Required by cwltool/Calrissian to evaluate `InlineJavascriptRequirement` expressions in CWL tools
- Without it, any CWL tool using `$(inputs.xxx)` syntax fails with: `NodeJSEngine requires Node.js engine to evaluate and validate Javascript expressions`

## Context
CWL tools that use `InlineJavascriptRequirement` (very common) need a JS engine. The echo-tool works because it doesn't use JS, but more complex tools do.