### PR TITLE
Add GDAL build dependencies for EURAC processes-dask fork

### DIFF
--- a/Dockerfile.executor
+++ b/Dockerfile.executor
@@ -15,7 +15,10 @@ RUN python3 -m venv $VIRTUAL_ENV && \
 
 ENV PATH="${POETRY_HOME}/bin:${VIRTUAL_ENV}/bin:${PATH}"
 
-RUN apt-get update && apt-get install -y libexpat1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libexpat1 libgdal-dev g++ && rm -rf /var/lib/apt/lists/*
+
+# Install GDAL Python bindings matching system GDAL version (required by xcube-eopf via EURAC processes-dask)
+RUN GDAL_VERSION=$(gdal-config --version) && $VIRTUAL_ENV/bin/pip install gdal==${GDAL_VERSION}
 
 RUN poetry install --only main
 
@@ -39,7 +42,7 @@ WORKDIR /opt/openeo_argoworkflows_executor
 COPY --from=base --chown=${USER_ID}:${GROUP_ID} /opt/openeo_argoworkflows_executor/.venv /opt/openeo_argoworkflows_executor/.venv
 COPY --chown=${USER_ID}:${GROUP_ID} ./openeo_argoworkflows/executor/openeo_argoworkflows_executor /opt/openeo_argoworkflows_executor
 
-RUN apt-get update && apt-get install -y libexpat1 nodejs && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libexpat1 libgdal32 nodejs && rm -rf /var/lib/apt/lists/*
 
 RUN ln -sf /usr/local/bin/python /opt/openeo_argoworkflows_executor/.venv/bin/python \
     && ln -sf /usr/local/bin/python3 /opt/openeo_argoworkflows_executor/.venv/bin/python3 \


### PR DESCRIPTION
## Summary
- Add `libgdal-dev` and `g++` to build stage for compiling GDAL Python bindings
- Install GDAL Python package matching system version before `poetry install`
- Add `libgdal32` runtime library to prod stage

## Context
PR #46 switched to the EURAC processes-dask fork, which includes `xcube-eopf` → `xcube_core` → `gdal`. The executor image build fails because `gdal-config` is not found.