### PR TITLE
Register run_cwl in API /processes endpoint

### DIFF
--- a/openeo_argoworkflows/api/openeo_argoworkflows_api/app.py
+++ b/openeo_argoworkflows/api/openeo_argoworkflows_api/app.py
@@ -1,4 +1,7 @@
 
+import json
+from pathlib import Path
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.responses import RedirectResponse
@@ -6,6 +9,7 @@ from starlette.responses import RedirectResponse
 from openeo_fastapi.api.app import OpenEOApi
 from openeo_fastapi.api.types import Billing, Plan, FileFormat, GisDataType
 from openeo_fastapi.client.core import OpenEOCore
+from openeo_pg_parser_networkx.process_registry import Process as pgProcess
 
 from openeo_argoworkflows_api.jobs import ArgoJobsRegister
 from openeo_argoworkflows_api.files import ArgoFileRegister
@@ -57,6 +61,15 @@ app.router.add_api_route(
 )
 
 api = OpenEOApi(client=client, app=app)
+
+# Register custom EURAC processes (not in upstream openeo-processes-dask)
+_specs_dir = Path(__file__).parent / "specs"
+for spec_file in _specs_dir.glob("*.json"):
+    with open(spec_file) as f:
+        spec = json.load(f)
+    api.client.processes.process_registry[("predefined", spec["id"])] = pgProcess(spec)
+# Clear the cached process list so it includes the new processes
+api.client.processes.get_available_processes.cache_clear()
 
 api.app.add_middleware(
     CORSMiddleware,

--- a/openeo_argoworkflows/api/openeo_argoworkflows_api/specs/run_cwl.json
+++ b/openeo_argoworkflows/api/openeo_argoworkflows_api/specs/run_cwl.json
@@ -1,0 +1,142 @@
+{
+    "id": "run_cwl",
+    "summary": "Run a CWL workflow",
+    "description": "Executes a Common Workflow Language (CWL) workflow or CommandLineTool.\n\nThe CWL document can be provided as an inline YAML/JSON string or as a URL pointing to a remote CWL file. The workflow is validated before execution. Inputs are passed as a flat key-value mapping corresponding to the CWL input parameters.\n\nOn the backend, validated CWL is executed through Calrissian on Kubernetes. Outputs are collected and exposed as standard openEO job results.\n\nThis is an MVP process. Only CWL v1.0\u20131.2 CommandLineTool and simple single-step Workflow documents are supported. Nested workflows, ScatterFeatureRequirements, and advanced CWL features are not guaranteed to work.",
+    "categories": [
+        "cubes",
+        "import"
+    ],
+    "experimental": true,
+    "parameters": [
+        {
+            "name": "cwl",
+            "description": "The CWL document to execute. Either an inline CWL string (YAML or JSON) or a URL pointing to a remote `.cwl` file (must be reachable from the backend).",
+            "schema": [
+                {
+                    "title": "Inline CWL",
+                    "description": "A CWL document provided as an inline YAML or JSON string.",
+                    "type": "string"
+                },
+                {
+                    "title": "Remote CWL URL",
+                    "description": "A URL pointing to a CWL file.",
+                    "type": "string",
+                    "format": "uri",
+                    "subtype": "uri",
+                    "pattern": "^https?://"
+                }
+            ]
+        },
+        {
+            "name": "inputs",
+            "description": "A flat key-value mapping of CWL input parameter names to their values. Keys must match the input IDs declared in the CWL document. Values can be strings, numbers, booleans, or objects (e.g. File references with `class: File` and `path` or `location`).",
+            "schema": {
+                "type": "object",
+                "title": "CWL Inputs",
+                "additionalProperties": {
+                    "description": "Any CWL-compatible input value."
+                }
+            }
+        },
+        {
+            "name": "options",
+            "description": "Optional execution flags.\n\n- `validate_only` (boolean, default `false`): If `true`, the CWL document is validated but not executed. The process returns immediately after validation.\n- `max_ram` (string, optional): Maximum RAM for concurrent CWL steps, e.g. `\"8G\"`. Defaults to backend configuration.\n- `max_cores` (integer, optional): Maximum CPU cores for concurrent CWL steps. Defaults to backend configuration.",
+            "schema": [
+                {
+                    "type": "object",
+                    "title": "Execution options",
+                    "properties": {
+                        "validate_only": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, validate the CWL document without executing it."
+                        },
+                        "max_ram": {
+                            "type": "string",
+                            "description": "Maximum RAM for concurrent CWL steps (e.g. '8G')."
+                        },
+                        "max_cores": {
+                            "type": "integer",
+                            "description": "Maximum CPU cores for concurrent CWL steps."
+                        }
+                    }
+                },
+                {
+                    "title": "No options",
+                    "description": "Use default execution settings.",
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "optional": true
+        }
+    ],
+    "returns": {
+        "description": "The CWL workflow output files, exposed as openEO job results. For `validate_only` mode, returns a validation status object.",
+        "schema": [
+            {
+                "type": "object",
+                "subtype": "datacube"
+            },
+            {
+                "type": "object",
+                "description": "Validation result when validate_only is true.",
+                "properties": {
+                    "valid": {
+                        "type": "boolean"
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "exceptions": {
+        "CwlInvalidDocument": {
+            "message": "The provided CWL document is not valid."
+        },
+        "CwlExecutionFailed": {
+            "message": "The CWL workflow execution failed."
+        },
+        "CwlInputMismatch": {
+            "message": "The provided inputs do not match the CWL document's declared input parameters."
+        }
+    },
+    "examples": [
+        {
+            "title": "Run a simple CWL CommandLineTool from URL",
+            "arguments": {
+                "cwl": "https://raw.githubusercontent.com/common-workflow-language/common-workflow-language/main/v1.0/v1.0/echo-tool.cwl",
+                "inputs": {
+                    "message": "Hello from openEO"
+                }
+            }
+        },
+        {
+            "title": "Validate a CWL document without running it",
+            "arguments": {
+                "cwl": "https://example.com/workflow.cwl",
+                "inputs": {},
+                "options": {
+                    "validate_only": true
+                }
+            }
+        }
+    ],
+    "links": [
+        {
+            "href": "https://www.commonwl.org/",
+            "rel": "about",
+            "title": "Common Workflow Language specification"
+        },
+        {
+            "href": "https://github.com/Duke-GCB/calrissian",
+            "rel": "about",
+            "title": "Calrissian: CWL runner for Kubernetes"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- Add `run_cwl.json` spec to `api/specs/` directory
- Register custom EURAC processes from `specs/` directory into the process registry at startup
- `run_cwl` now appears in `/processes` and the Web Editor process list

## Context
The API uses upstream `openeo-processes-dask` (via `openeo_fastapi`) which doesn't include `run_cwl`. The executor has it (PR #46 switched to EURAC fork), but the API needs to advertise it too. This approach loads custom specs without requiring a fork of `openeo_fastapi`.

Future custom processes can be added by dropping a JSON spec file into the `specs/` directory.