### PR TITLE
Fix executor image: restore openeo_executor entry point

### DIFF
--- a/Dockerfile.executor
+++ b/Dockerfile.executor
@@ -23,13 +23,16 @@ RUN apt-get update && apt-get install -y libexpat1 libgdal-dev g++ && rm -rf /va
 RUN GDAL_VERSION=$(gdal-config --version) && \
     $VIRTUAL_ENV/bin/pip install --no-cache-dir "gdal==${GDAL_VERSION}"
 
-# Install all other dependencies via Poetry. The pre-installed gdal satisfies
-# xcube-core's requirement. Poetry may warn about version mismatch but will
-# not reinstall it.
-RUN poetry install --only main || true
-# Force-reinstall system-matching gdal in case poetry overwrote it
-RUN GDAL_VERSION=$(gdal-config --version) && \
-    $VIRTUAL_ENV/bin/pip install --no-cache-dir --force-reinstall "gdal==${GDAL_VERSION}"
+# Export dependencies from poetry lock, exclude gdal (already installed from system),
+# then install via pip. This avoids poetry trying to build gdal 3.12.2 against
+# system libgdal 3.6.2 headers which causes a version mismatch build failure.
+RUN poetry export --only main --without-hashes -o /tmp/requirements.txt && \
+    grep -v "^gdal==" /tmp/requirements.txt > /tmp/requirements-no-gdal.txt && \
+    $VIRTUAL_ENV/bin/pip install --no-cache-dir -r /tmp/requirements-no-gdal.txt && \
+    rm /tmp/requirements.txt /tmp/requirements-no-gdal.txt
+
+# Install the project itself to create the openeo_executor CLI entry point
+RUN $VIRTUAL_ENV/bin/pip install --no-deps --no-cache-dir .
 
 # Install raster2stac separately to avoid pystac version conflict with openeo-processes-dask
 # Install all raster2stac deps (except pystac) with full resolution, then raster2stac with --no-deps
@@ -39,6 +42,9 @@ RUN $VIRTUAL_ENV/bin/pip install boto3 dask fsspec h5netcdf h5py kerchunk netcdf
 
 # Install CWL execution dependencies (calrissian for K8s CWL runner, cwltool for validation)
 RUN $VIRTUAL_ENV/bin/pip install calrissian cwltool
+
+# Verify the entry point exists
+RUN which openeo_executor
 
 ########################################################################################################################
 FROM python:3.11-slim-bookworm AS prod


### PR DESCRIPTION
## Problem
PR #48 used `poetry install --only main || true` which silently failed due to GDAL version mismatch (lock: 3.12.2 vs system: 3.6.2). The `|| true` swallowed the error, so the `openeo_executor` CLI entry point was never created. All executor pods fail with:

```
exec: "openeo_executor": executable file not found in $PATH
```

## Fix
- Use `poetry export` → `pip install -r` (excluding gdal) instead of `poetry install`
- Add `pip install --no-deps .` to install the project package and create the entry point
- Add `which openeo_executor` verification so the build fails early if the entry point is missing

## Root cause
Poetry tries to build `gdal==3.12.2` from the lock file against system `libgdal-dev 3.6.2` headers — version mismatch. The `|| true` masked this failure.