### PR TITLE
fix(docker): install git for EURAC fork dependency

### DIFF
--- a/Dockerfile.executor
+++ b/Dockerfile.executor
@@ -15,7 +15,7 @@ RUN python3 -m venv $VIRTUAL_ENV && \
 
 ENV PATH="${POETRY_HOME}/bin:${VIRTUAL_ENV}/bin:${PATH}"
 
-RUN apt-get update && apt-get install -y libexpat1 libgdal-dev g++ && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libexpat1 libgdal-dev g++ git && rm -rf /var/lib/apt/lists/*
 
 # Install GDAL Python bindings matching system libgdal version.
 # xcube-eopf (from EURAC processes-dask) requires gdal, but the PyPI version


### PR DESCRIPTION
## Summary
- PR #50 switched to `poetry export` + `pip install -r` to avoid GDAL build conflicts
- The exported requirements.txt contains `openeo-processes-dask @ git+https://...` (EURAC fork from PR #46)
- `pip` needs `git` to clone it, but `python:3.11-slim-bookworm` doesn't include git
- Adds `git` to the `apt-get install` in the build stage

## Root cause
```
ERROR: Error [Errno 2] No such file or directory: 'git' while executing command git version
ERROR: Cannot find command 'git' - do you have 'git' installed and in your PATH?
```

Fixes the failed build after PR #50 merge.