### PR TITLE
fix(docker): rewrite SSH submodule URLs to HTTPS for CI builds

### DIFF
--- a/Dockerfile.executor
+++ b/Dockerfile.executor
@@ -15,7 +15,8 @@ RUN python3 -m venv $VIRTUAL_ENV && \
 
 ENV PATH="${POETRY_HOME}/bin:${VIRTUAL_ENV}/bin:${PATH}"
 
-RUN apt-get update && apt-get install -y libexpat1 libgdal-dev g++ git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libexpat1 libgdal-dev g++ git && rm -rf /var/lib/apt/lists/* && \
+    git config --global url."https://github.com/".insteadOf "git@github.com:"
 
 # Install GDAL Python bindings matching system libgdal version.
 # xcube-eopf (from EURAC processes-dask) requires gdal, but the PyPI version


### PR DESCRIPTION
## Summary
- EURAC `openeo-processes-dask` fork has a git submodule pointing to `git@github.com:eodcgmbh/openeo-processes.git` (SSH URL)
- During Docker build, `git submodule update --init --recursive` fails with "Host key verification failed" because there are no SSH keys in the CI environment
- Fix: `git config --global url."https://github.com/".insteadOf "git@github.com:"` rewrites SSH URLs to HTTPS

## Context
Follows PR #51 which added `git` to the build stage. Git clone now works but submodule init fails on SSH URLs.