### PR TITLE
fix(docker): create entry point script to avoid poetry-core path bug

### DIFF
--- a/Dockerfile.executor
+++ b/Dockerfile.executor
@@ -32,8 +32,11 @@ RUN poetry export --only main --without-hashes -o /tmp/requirements.txt && \
     $VIRTUAL_ENV/bin/pip install --no-cache-dir -r /tmp/requirements-no-gdal.txt && \
     rm /tmp/requirements.txt /tmp/requirements-no-gdal.txt
 
-# Install the project itself to create the openeo_executor CLI entry point
-RUN $VIRTUAL_ENV/bin/pip install --no-deps --no-cache-dir .
+# Create the openeo_executor CLI entry point script directly.
+# Avoids pip install . which triggers poetry-core's path validation bug
+# ("'/usr/local/bin/python3.11' is not in the subpath of '/opt'").
+RUN printf '#!/opt/openeo_argoworkflows_executor/.venv/bin/python\nfrom openeo_argoworkflows_executor.cli import cli\ncli()\n' > $VIRTUAL_ENV/bin/openeo_executor && \
+    chmod +x $VIRTUAL_ENV/bin/openeo_executor
 
 # Install raster2stac separately to avoid pystac version conflict with openeo-processes-dask
 # Install all raster2stac deps (except pystac) with full resolution, then raster2stac with --no-deps


### PR DESCRIPTION
## Summary
- `pip install --no-deps .` fails during Docker build with: `ValueError: '/usr/local/bin/python3.11' is not in the subpath of '/opt'`
- This is a poetry-core bug when the Python interpreter is outside the project WORKDIR
- Fix: create the `openeo_executor` entry point script manually, matching what pip would generate from `pyproject.toml` scripts config (`openeo_argoworkflows_executor.cli:cli`)

## Context
Follows PR #52 (SSH→HTTPS rewrite). The submodule issue is now fixed but this poetry-core path validation error blocks the build.