### PR TITLE
fix(docker): add PYTHONPATH for executor module import

### DIFF
--- a/Dockerfile.executor
+++ b/Dockerfile.executor
@@ -71,6 +71,7 @@ RUN ln -sf /usr/local/bin/python /opt/openeo_argoworkflows_executor/.venv/bin/py
 ENV VIRTUAL_ENV=/opt/openeo_argoworkflows_executor/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ENV DASK_GATEWAY_SERVER="http://traefik-openeo-dask-gateway.openeo.svc.cluster.local:80"
+ENV PYTHONPATH="/opt"
 
 # Calrissian inspects containers[0] for PVC mounts. In Argo Workflow pods,
 # containers[0] is the 'wait' sidecar which mounts the workspace PVC at


### PR DESCRIPTION
## Summary
- Executor fails at runtime with `ModuleNotFoundError: No module named 'openeo_argoworkflows_executor'`
- Source is at `/opt/openeo_argoworkflows_executor/` but `/opt` is not on `sys.path`
- Fix: `ENV PYTHONPATH="/opt"` in the prod stage

## Context
PR #53 replaced `pip install .` with a manual entry point script to avoid poetry-core's path bug. But without `pip install`, the package isn't registered in site-packages, so PYTHONPATH is needed.