### PR TITLE
fix(dimensions): normalize dimension names in API and resolve aliases in executor

### DIFF
--- a/openeo_argoworkflows/api/Dockerfile
+++ b/openeo_argoworkflows/api/Dockerfile
@@ -21,12 +21,15 @@ ENV PATH="${POETRY_HOME}/bin:${VIRTUAL_ENV}/bin:${PATH}"
 
 RUN poetry install --only main
 
-# Patch openeo-fastapi library: replace hardcoded EGI Check-in with env-based OIDC config,
-# disable JWT audience validation for EURAC Keycloak compatibility,
-# and extend Dimension model to preserve band names and spatial metadata from STAC.
+# Patch openeo-fastapi library:
+# - core.py: env-based OIDC config (replace hardcoded EGI Check-in)
+# - auth.py: disable JWT audience validation for EURAC Keycloak
+# - types.py: extend Dimension model to preserve band names and spatial metadata
+# - collections.py: normalize dimension names to OpenEO standard (x, y, t, bands)
 COPY ./patches/openeo_fastapi_core.py ${VIRTUAL_ENV}/lib/python3.11/site-packages/openeo_fastapi/client/core.py
 COPY ./patches/openeo_fastapi_auth.py ${VIRTUAL_ENV}/lib/python3.11/site-packages/openeo_fastapi/client/auth.py
 COPY ./patches/openeo_fastapi_types.py ${VIRTUAL_ENV}/lib/python3.11/site-packages/openeo_fastapi/api/types.py
+COPY ./patches/openeo_fastapi_collections.py ${VIRTUAL_ENV}/lib/python3.11/site-packages/openeo_fastapi/client/collections.py
 
 COPY --chown=${USER_ID}:${GROUP_ID} ./openeo_argoworkflows_api /opt/openeo_argoworkflows_api
 

--- a/openeo_argoworkflows/api/patches/openeo_fastapi_collections.py
+++ b/openeo_argoworkflows/api/patches/openeo_fastapi_collections.py
@@ -1,0 +1,258 @@
+"""Class and model to define the framework and partial application logic for interacting with Collections.
+
+Classes:
+    - CollectionRegister: Framework for defining and extending the logic for working with Collections.
+
+Patched to normalize cube:dimensions keys to OpenEO standard names
+(x, y, t, bands) so users don't need to know each STAC catalog's
+naming conventions.
+"""
+import logging
+
+import aiohttp
+from fastapi import HTTPException
+
+from openeo_fastapi.api.models import Collection, Collections
+from openeo_fastapi.api.types import Endpoint, Error
+from openeo_fastapi.client.register import EndpointRegister
+
+logger = logging.getLogger(__name__)
+
+# Mapping of non-standard dimension names to OpenEO standard names.
+# Built from a survey of 136 collections on stac.eurac.edu.
+_DIMENSION_NAME_MAP = {
+    # spatial x
+    "X": "x",
+    "E": "x",
+    "Lon": "x",
+    "lon": "x",
+    "longitude": "x",
+    # spatial y
+    "Y": "y",
+    "N": "y",
+    "Lat": "y",
+    "lat": "y",
+    "latitude": "y",
+    # temporal
+    "DATE": "t",
+    "time": "t",
+    # bands
+    "band": "bands",
+}
+
+
+def _normalize_dimensions(collection_dict):
+    """Rename cube:dimensions keys to OpenEO standard names (x, y, t, bands).
+
+    Modifies the dict in place and returns it.
+    """
+    dims = collection_dict.get("cube:dimensions")
+    if not dims or not isinstance(dims, dict):
+        return collection_dict
+
+    normalized = {}
+    for name, dim in dims.items():
+        standard_name = _DIMENSION_NAME_MAP.get(name, name)
+        if standard_name != name:
+            logger.debug(
+                "Collection %s: renaming dimension '%s' -> '%s'",
+                collection_dict.get("id", "?"),
+                name,
+                standard_name,
+            )
+        normalized[standard_name] = dim
+
+    collection_dict["cube:dimensions"] = normalized
+    return collection_dict
+
+COLLECTIONS_ENDPOINTS = [
+    Endpoint(
+        path="/collections",
+        methods=["GET"],
+    ),
+    Endpoint(
+        path="/collections/{collection_id}",
+        methods=["GET"],
+    ),
+    Endpoint(
+        path="/collections/{collection_id}/items",
+        methods=["GET"],
+    ),
+    Endpoint(
+        path="/collections/{collection_id}/items/{item_id}",
+        methods=["GET"],
+    ),
+]
+
+
+class CollectionRegister(EndpointRegister):
+    """The CollectionRegister to regulate the application logic for the API behaviour.
+    """
+    
+    def __init__(self, settings) -> None:
+        """Initialize the CollectionRegister.
+
+        Args:
+            settings (AppSettings): The AppSettings that the application will use.
+        """
+        super().__init__()
+        self.endpoints = self._initialize_endpoints()
+        self.settings = settings
+
+    def _initialize_endpoints(self) -> list[Endpoint]:
+        """Initialize the endpoints for the register.
+
+        Returns:
+            list[Endpoint]: The default list of job endpoints which are packaged with the module.
+        """
+        return COLLECTIONS_ENDPOINTS
+
+    async def _proxy_request(self, path):
+        """Proxy the request with aiohttp.
+
+        Args:
+            path (str): The path to proxy to the STAC catalogue.
+
+        Raises:
+            HTTPException: Raises an exception with relevant status code and descriptive message of failure.
+
+        Returns:
+            The response dictionary from the request.
+        """
+        async with aiohttp.ClientSession() as client:
+            async with client.get(self.settings.STAC_API_URL + path) as response:
+                resp = await response.json()
+                if response.status == 200:
+                    return resp
+
+    async def get_collection(self, collection_id):
+        """
+        Returns Metadata for specific datasetsbased on collection_id (str).
+        
+        Args:
+            collection_id (str): The collection id to request from the proxy.
+
+        Raises:
+            HTTPException: Raises an exception with relevant status code and descriptive message of failure.
+
+        Returns:
+            Collection: The proxied request returned as a Collection.
+        """
+        not_found = Error(
+                code="NotFound", message=f"Collection {collection_id} not found."
+            )
+
+        if (
+            not self.settings.STAC_COLLECTIONS_WHITELIST
+            or collection_id in self.settings.STAC_COLLECTIONS_WHITELIST
+        ):
+            path = f"collections/{collection_id}"
+            resp = await self._proxy_request(path)
+
+            if resp:
+                _normalize_dimensions(resp)
+                return Collection(**resp)
+            raise HTTPException(
+                status_code=404,
+                detail=not_found
+            )
+        raise HTTPException(
+            status_code=404,
+            detail=not_found
+        )
+
+    async def get_collections(self):
+        """
+        Returns Basic metadata for all datasets
+
+        Raises:
+            HTTPException: Raises an exception with relevant status code and descriptive message of failure.
+
+        Returns:
+            Collections: The proxied request returned as a Collections object.
+        """
+        path = "collections"
+        resp = await self._proxy_request(path)
+
+        if resp:
+            collections_list = [
+                _normalize_dimensions(collection)
+                for collection in resp["collections"]
+                if (
+                    not self.settings.STAC_COLLECTIONS_WHITELIST
+                    or collection["id"] in self.settings.STAC_COLLECTIONS_WHITELIST
+                )
+            ]
+
+            return Collections(collections=collections_list, links=resp["links"])
+        else:
+            raise HTTPException(
+                status_code=404,
+                detail=Error(code="NotFound", message="No Collections found."),
+            )
+
+    async def get_collection_items(self, collection_id):
+        """
+        Returns Basic metadata for all datasets.
+        
+        Args:
+            collection_id (str): The collection id to request from the proxy.
+
+        Raises:
+            HTTPException: Raises an exception with relevant status code and descriptive message of failure.
+
+        Returns:
+            The direct response from the request to the stac catalogue.
+        """
+        not_found = HTTPException(
+            status_code=404,
+            detail=Error(
+                code="NotFound", message=f"Collection {collection_id} not found."
+            ),
+        )
+
+        if (
+            not self.settings.STAC_COLLECTIONS_WHITELIST
+            or collection_id in self.settings.STAC_COLLECTIONS_WHITELIST
+        ):
+            path = f"collections/{collection_id}/items"
+            resp = await self._proxy_request(path)
+
+            if resp:
+                return resp
+            raise not_found
+        raise not_found
+
+    async def get_collection_item(self, collection_id, item_id):
+        """
+        Returns Basic metadata for all datasets
+        
+        Args:
+            collection_id (str): The collection id to request from the proxy.
+            item_id (str): The item id to request from the proxy.
+
+        Raises:
+            HTTPException: Raises an exception with relevant status code and descriptive message of failure.
+
+        Returns:
+            The direct response from the request to the stac catalogue.
+        """
+        not_found = HTTPException(
+            status_code=404,
+            detail=Error(
+                code="NotFound",
+                message=f"Item {item_id} not found in collection {collection_id}.",
+            ),
+        )
+
+        if (
+            not self.settings.STAC_COLLECTIONS_WHITELIST
+            or collection_id in self.settings.STAC_COLLECTIONS_WHITELIST
+        ):
+            path = f"collections/{collection_id}/items/{item_id}"
+            resp = await self._proxy_request(path)
+
+            if resp:
+                return resp
+            raise not_found
+        raise not_found

--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/__init__.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/__init__.py
@@ -1,2 +1,3 @@
 from .cwl import *
 from .io import *
+from .reduce import *

--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/reduce.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/reduce.py
@@ -1,0 +1,63 @@
+"""Wrapper around reduce_dimension that resolves dimension name aliases.
+
+STAC catalogs use inconsistent dimension names (DATE, time, X, Y, Lon, etc.)
+while odc-stac normalizes xarray dims to (t, x, y, bands). Users writing
+process graphs may use either convention. This wrapper maps common aliases
+to the actual xarray dim name before calling the upstream implementation.
+"""
+import logging
+from typing import Callable, Optional
+
+from openeo_processes_dask.process_implementations.cubes.reduce import (
+    reduce_dimension as _upstream_reduce_dimension,
+)
+from openeo_processes_dask.process_implementations.data_model import RasterCube
+
+__all__ = ["reduce_dimension"]
+
+logger = logging.getLogger(__name__)
+
+# Map common user-facing names to the xarray dim names produced by odc-stac
+_DIMENSION_ALIASES = {
+    # temporal
+    "time": "t",
+    "DATE": "t",
+    "date": "t",
+    "temporal": "t",
+    # spatial x
+    "X": "x",
+    "E": "x",
+    "Lon": "x",
+    "lon": "x",
+    "longitude": "x",
+    # spatial y
+    "Y": "y",
+    "N": "y",
+    "Lat": "y",
+    "lat": "y",
+    "latitude": "y",
+    # bands
+    "band": "bands",
+}
+
+
+def reduce_dimension(
+    data: RasterCube,
+    reducer: Callable,
+    dimension: str,
+    context: Optional[dict] = None,
+) -> RasterCube:
+    if dimension not in data.dims and dimension in _DIMENSION_ALIASES:
+        resolved = _DIMENSION_ALIASES[dimension]
+        if resolved in data.dims:
+            logger.info(
+                "Resolved dimension alias '%s' -> '%s' (available: %s)",
+                dimension,
+                resolved,
+                list(data.dims),
+            )
+            dimension = resolved
+
+    return _upstream_reduce_dimension(
+        data=data, reducer=reducer, dimension=dimension, context=context
+    )

--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/specs/reduce_dimension.json
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/specs/reduce_dimension.json
@@ -1,0 +1,91 @@
+{
+    "id": "reduce_dimension",
+    "summary": "Reduce dimensions",
+    "description": "Applies a reducer to a data cube dimension by collapsing all the values along the specified dimension into an output value computed by the reducer.\n\nThe dimension is dropped. To avoid this, use ``apply_dimension()`` instead.",
+    "categories": [
+        "cubes",
+        "reducer"
+    ],
+    "parameters": [
+        {
+            "name": "data",
+            "description": "A data cube.",
+            "schema": {
+                "type": "object",
+                "subtype": "datacube"
+            }
+        },
+        {
+            "name": "reducer",
+            "description": "A reducer to apply on the specified dimension. A reducer is a single process such as ``mean()`` or a set of processes, which computes a single value for a list of values, see the category 'reducer' for such processes.",
+            "schema": {
+                "type": "object",
+                "subtype": "process-graph",
+                "parameters": [
+                    {
+                        "name": "data",
+                        "description": "A labeled array with elements of any type.",
+                        "schema": {
+                            "type": "array",
+                            "subtype": "labeled-array",
+                            "items": {
+                                "description": "Any data type."
+                            }
+                        }
+                    },
+                    {
+                        "name": "context",
+                        "description": "Additional data passed by the user.",
+                        "schema": {
+                            "description": "Any data type."
+                        },
+                        "optional": true,
+                        "default": null
+                    }
+                ],
+                "returns": {
+                    "description": "The value to be set in the new data cube.",
+                    "schema": {
+                        "description": "Any data type."
+                    }
+                }
+            }
+        },
+        {
+            "name": "dimension",
+            "description": "The name of the dimension over which to reduce. Fails with a `DimensionNotAvailable` exception if the specified dimension does not exist.",
+            "schema": {
+                "type": "string"
+            }
+        },
+        {
+            "name": "context",
+            "description": "Additional data to be passed to the reducer.",
+            "schema": {
+                "description": "Any data type."
+            },
+            "optional": true,
+            "default": null
+        }
+    ],
+    "returns": {
+        "description": "A data cube with the newly computed values. It is missing the given dimension, the number of dimensions decreases by one. The dimension properties (name, type, labels, reference system and resolution) for all other dimensions remain unchanged.",
+        "schema": {
+            "type": "object",
+            "subtype": "datacube"
+        }
+    },
+    "exceptions": {
+        "DimensionNotAvailable": {
+            "message": "A dimension with the specified name does not exist."
+        }
+    },
+    "links": [
+        {
+            "href": "https://openeo.org/documentation/1.0/datacubes.html#reduce",
+            "rel": "about",
+            "title": "Reducers explained in the openEO documentation"
+        }
+    ]
+}
+


### PR DESCRIPTION
## Summary

STAC catalogs use inconsistent dimension names (`DATE`, `time`, `X`, `Y`, `Lon`, `latitude`, etc.) across 136 collections. This causes `DimensionNotAvailable` errors when process graphs use names that don't match the xarray dims produced by `odc-stac`.

**API side:**
- New `collections.py` patch normalizes `cube:dimensions` keys to OpenEO standard names (`X`→`x`, `Y`→`y`, `DATE`/`time`→`t`, `band`→`bands`) before serving to clients
- Users now see consistent dimension names in the Web Editor and Python client

**Executor side:**
- New `reduce_dimension` wrapper resolves common dimension aliases (`time`→`t`, `DATE`→`t`, etc.) before calling the upstream implementation
- Prevents `DimensionNotAvailable` when process graphs use non-standard names

Dimension name survey across all 136 STAC collections:
| Current names | Standard | Count |
|---|---|---|
| `X`, `E`, `Lon`, `longitude`, `lon` | `x` | 96 |
| `Y`, `N`, `Lat`, `latitude`, `lat` | `y` | 96 |
| `DATE`, `time` | `t` | 92 |
| `band` | `bands` | 1 |

Partial fix for #56.