### PR TITLE
fix(save_result): drop non-serializable attrs before writing netCDF

### DIFF
--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/io.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/io.py
@@ -374,6 +374,14 @@ def save_result(
             out_data["y"].attrs["standard_name"] = "projection_y_coordinate"
             out_data["y"].attrs["long_name"] = "y coordinate of projection"
 
+    # Remove attrs that are not netCDF-serializable (dicts, objects, etc.)
+    # e.g. reduced_dimensions_min_values is a dict set by reduce_dimension
+    valid_types = (str, int, float, bytes, list, tuple, np.ndarray, np.generic)
+    for key in list(out_data.attrs):
+        if not isinstance(out_data.attrs[key], valid_types):
+            logger.debug(f"Dropping non-serializable attr '{key}': {type(out_data.attrs[key])}")
+            del out_data.attrs[key]
+
     logger.info(f"Writing netCDF to: {destination}")
     out_data.to_netcdf(path=destination, encoding=encoding)
 


### PR DESCRIPTION
## Summary

- `reduce_dimension` stores `reduced_dimensions_min_values` as a dict in xarray attrs
- netCDF doesn't accept dicts as attribute values — `to_netcdf()` raises `TypeError`
- Fix: strip any non-serializable attrs (dicts, objects) before calling `to_netcdf()`
- PR #62 fixed the `datetime64` inside the dict, but the dict itself was still invalid

Error: `TypeError: Invalid value for attr 'reduced_dimensions_min_values': {'t': '2025-06-01T12:02:46.440000000'}`