### PR TITLE
fix(executor): strip non-serializable attrs from data variables

### DIFF
--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/io.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/io.py
@@ -392,8 +392,13 @@ def save_result(
     valid_types = (str, int, float, bytes, list, tuple, np.ndarray, np.generic)
     for key in list(out_data.attrs):
         if not isinstance(out_data.attrs[key], valid_types):
-            logger.debug(f"Dropping non-serializable attr '{key}': {type(out_data.attrs[key])}")
+            logger.debug(f"Dropping non-serializable dataset attr '{key}': {type(out_data.attrs[key])}")
             del out_data.attrs[key]
+    for var in out_data.data_vars:
+        for key in list(out_data[var].attrs):
+            if not isinstance(out_data[var].attrs[key], valid_types):
+                logger.debug(f"Dropping non-serializable attr '{key}' on '{var}': {type(out_data[var].attrs[key])}")
+                del out_data[var].attrs[key]
 
     logger.info(f"Writing netCDF to: {destination}")
     out_data.to_netcdf(path=destination, encoding=encoding)


### PR DESCRIPTION
The attr stripping only cleaned Dataset-level attrs, but `reduced_dimensions_min_values` (a dict) was also present on data variable attrs, causing `to_netcdf()` to fail with TypeError.