### PR TITLE
fix: deduplicate endpoints in capabilities response

### DIFF
--- a/openeo_argoworkflows/api/patches/openeo_fastapi_core.py
+++ b/openeo_argoworkflows/api/patches/openeo_fastapi_core.py
@@ -87,10 +87,15 @@ class OpenEOCore:
         """
         registers = [self.collections, self.files, self.jobs, self.processes]
 
-        endpoints = self.endpoints
+        endpoints = list(self.endpoints)
+        seen = {(e.path, m) for e in endpoints for m in e.methods}
         for register in registers:
             if register:
-                endpoints.extend(register.endpoints)
+                for e in register.endpoints:
+                    for m in e.methods:
+                        if (e.path, m) not in seen:
+                            seen.add((e.path, m))
+                            endpoints.append(e)
         return endpoints
 
     def get_capabilities(self) -> Capabilities:


### PR DESCRIPTION
## Problem

`GET /` returns duplicate endpoints on every request. The root cause is in `_combine_endpoints()` in `openeo_fastapi_core.py`:

```python
endpoints = self.endpoints  # assigns reference, not copy
endpoints.extend(register.endpoints)  # mutates the class-level list
```

Each call to `get_capabilities()` appends all register endpoints to the shared `APPLICATION_ENDPOINTS` class variable. After N requests, the list has N copies of every endpoint.

## Fix

- Copy the list with `list(self.endpoints)` before appending
- Deduplicate by `(path, method)` pair so even overlapping registrations only appear once

Fixes #81