### PR TITLE
ci: trigger image builds on eurac-main

### DIFF
--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - eurac-main
     paths:
       - 'openeo_argoworkflows/api/**'
   workflow_dispatch:

--- a/.github/workflows/build-executor.yaml
+++ b/.github/workflows/build-executor.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - eurac-main
     paths:
       - 'Dockerfile.executor'
       - 'openeo_argoworkflows/executor/openeo_argoworkflows_executor/**'


### PR DESCRIPTION
Add eurac-main to build triggers so merging to eurac-main builds and pushes API and executor images.