### PR TITLE
fix: add /file_formats to APPLICATION_ENDPOINTS so it appears in capabilities

### DIFF
--- a/openeo_argoworkflows/api/patches/openeo_fastapi_core.py
+++ b/openeo_argoworkflows/api/patches/openeo_fastapi_core.py
@@ -48,6 +48,10 @@ APPLICATION_ENDPOINTS = [
         path="/credentials/oidc",
         methods=["GET"],
     ),
+    Endpoint(
+        path="/file_formats",
+        methods=["GET"],
+    ),
 ]
 
 


### PR DESCRIPTION
## Problem

The `/file_formats` route returns correct data but was not listed in the `endpoints` array of the capabilities response (`GET /`). The Web Editor reads this array to discover backend capabilities and populate **Export File Formats** — showing 0 because the endpoint wasn't advertised.

## Fix

Add `/file_formats` to `APPLICATION_ENDPOINTS` in `openeo_fastapi_core.py` patch so it appears in the capabilities endpoints list.

## Related

Closes #85