### PR TITLE
feat(udf): add EOAP-CWL runtime to /udf_runtimes and /processes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -67,5 +67,5 @@ jobs:
           # Change this to be your CI task/script
           runCmd: |
             poetry config virtualenvs.in-project true
-            poetry install --with dev --all-extras
+            poetry install --with dev
             poetry run pytest 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,10 +62,14 @@ jobs:
       - name: Build and run dev container task
         if: ${{ steps.changes.outputs.executor == 'true' }}
         uses: devcontainers/ci@v0.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           subFolder: openeo_argoworkflows/executor
+          inheritEnv: true
           # Change this to be your CI task/script
           runCmd: |
+            git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
             poetry config virtualenvs.in-project true
             poetry install --with dev
             poetry run pytest 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,14 +62,11 @@ jobs:
       - name: Build and run dev container task
         if: ${{ steps.changes.outputs.executor == 'true' }}
         uses: devcontainers/ci@v0.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           subFolder: openeo_argoworkflows/executor
-          env: GITHUB_TOKEN
           # Change this to be your CI task/script
           runCmd: |
-            git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+            git config --global url."https://github.com/".insteadOf "git@github.com:"
             poetry config virtualenvs.in-project true
             poetry install --with dev
             poetry run pytest 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -66,7 +66,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           subFolder: openeo_argoworkflows/executor
-          inheritEnv: true
+          env: GITHUB_TOKEN
           # Change this to be your CI task/script
           runCmd: |
             git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"

--- a/openeo_argoworkflows/api/.devcontainer/Dockerfile
+++ b/openeo_argoworkflows/api/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-ARG VARIANT="3.11-bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT} as devcontainer
+ARG VARIANT="3.11-bookworm"
+FROM mcr.microsoft.com/devcontainers/python:1-${VARIANT} as devcontainer
 
 ENV POETRY_VIRTUALENVS_IN_PROJECT 1
 

--- a/openeo_argoworkflows/api/.devcontainer/Dockerfile
+++ b/openeo_argoworkflows/api/.devcontainer/Dockerfile
@@ -7,7 +7,8 @@ ENV POETRY_VIRTUALENVS_IN_PROJECT 1
 ARG POETRY_VERSION="1.8.3"
 RUN if [ "${POETRY_VERSION}" != "none" ]; then su vscode -c "umask 0002 && pip3 install poetry==${POETRY_VERSION}"; fi
 
-RUN apt update -qy && \
+RUN rm -f /etc/apt/sources.list.d/yarn.list && \
+    apt update -qy && \
     apt install -qy --no-install-recommends \
         postgresql-13 \
         git

--- a/openeo_argoworkflows/api/.devcontainer/Dockerfile
+++ b/openeo_argoworkflows/api/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT="3.11-bookworm"
+ARG VARIANT="3.11-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT} as devcontainer
 
 ENV POETRY_VIRTUALENVS_IN_PROJECT 1
@@ -9,7 +9,7 @@ RUN if [ "${POETRY_VERSION}" != "none" ]; then su vscode -c "umask 0002 && pip3 
 
 RUN apt update -qy && \
     apt install -qy --no-install-recommends \
-        postgresql-15 \
+        postgresql-13 \
         git
 
 WORKDIR /openeo_argoworkflows_api

--- a/openeo_argoworkflows/api/.devcontainer/Dockerfile
+++ b/openeo_argoworkflows/api/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT="3.11-bullseye"
+ARG VARIANT="3.11-bookworm"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT} as devcontainer
 
 ENV POETRY_VIRTUALENVS_IN_PROJECT 1
@@ -9,7 +9,7 @@ RUN if [ "${POETRY_VERSION}" != "none" ]; then su vscode -c "umask 0002 && pip3 
 
 RUN apt update -qy && \
     apt install -qy --no-install-recommends \
-        postgresql-13 \
+        postgresql-15 \
         git
 
 WORKDIR /openeo_argoworkflows_api

--- a/openeo_argoworkflows/api/.devcontainer/Dockerfile
+++ b/openeo_argoworkflows/api/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ RUN if [ "${POETRY_VERSION}" != "none" ]; then su vscode -c "umask 0002 && pip3 
 RUN rm -f /etc/apt/sources.list.d/yarn.list && \
     apt update -qy && \
     apt install -qy --no-install-recommends \
-        postgresql-13 \
+        postgresql \
         git
 
 WORKDIR /openeo_argoworkflows_api

--- a/openeo_argoworkflows/api/openeo_argoworkflows_api/specs/run_udf.json
+++ b/openeo_argoworkflows/api/openeo_argoworkflows_api/specs/run_udf.json
@@ -1,0 +1,92 @@
+{
+    "id": "run_udf",
+    "summary": "Run a UDF (User-Defined Function) or EOAP-CWL workflow",
+    "description": "Runs a user-defined function (UDF) or an EOAP-CWL workflow against a data cube.\n\nThis backend supports the `EOAP-CWL` runtime. Pass the CWL document as the `udf` parameter and the CWL input values as the `context` parameter.\n\nThe endorsed staging pattern is: `load_collection → save_result → context → run_udf(EOAP-CWL)`. The CWL workflow receives files staged by `save_result` and must produce a STAC catalog as output.",
+    "categories": [
+        "cubes",
+        "import"
+    ],
+    "experimental": true,
+    "parameters": [
+        {
+            "name": "data",
+            "description": "The data to process. May be null when using EOAP-CWL with pre-staged inputs.",
+            "schema": [
+                {
+                    "type": "object",
+                    "subtype": "datacube"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "optional": true,
+            "default": null
+        },
+        {
+            "name": "udf",
+            "description": "The UDF code or CWL document to execute. For `EOAP-CWL` runtime: provide the CWL document as an inline YAML/JSON string or a URL pointing to a remote `.cwl` file.",
+            "schema": [
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        {
+            "name": "runtime",
+            "description": "The UDF runtime identifier. Use `EOAP-CWL` to execute a CWL workflow via Calrissian on Kubernetes.",
+            "schema": [
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        {
+            "name": "version",
+            "description": "The runtime version. For `EOAP-CWL`, use `\"1\"` (default).",
+            "schema": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "optional": true,
+            "default": null
+        },
+        {
+            "name": "context",
+            "description": "Additional context passed to the UDF. For `EOAP-CWL` runtime: a flat key-value mapping of CWL input parameter names to their values.",
+            "schema": [
+                {
+                    "type": "object"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "optional": true,
+            "default": null
+        }
+    ],
+    "returns": {
+        "description": "The processed data cube or CWL workflow outputs.",
+        "schema": [
+            {
+                "type": "object",
+                "subtype": "datacube"
+            },
+            {
+                "type": "object"
+            }
+        ]
+    },
+    "links": [
+        {
+            "href": "https://www.commonwl.org/",
+            "rel": "about",
+            "title": "Common Workflow Language specification"
+        }
+    ]
+}

--- a/openeo_argoworkflows/api/patches/openeo_fastapi_core.py
+++ b/openeo_argoworkflows/api/patches/openeo_fastapi_core.py
@@ -244,4 +244,15 @@ class OpenEOCore:
         Returns:
             UdfRuntimesGetResponse: The UDF runtimes available in this api deployment.
         """
-        return {}
+        return {
+            "EOAP-CWL": {
+                "title": "EOAP-CWL",
+                "type": "language",
+                "default": "1",
+                "versions": {
+                    "1": {
+                        "libraries": {}
+                    }
+                }
+            }
+        }

--- a/openeo_argoworkflows/executor/.devcontainer/Dockerfile
+++ b/openeo_argoworkflows/executor/.devcontainer/Dockerfile
@@ -10,6 +10,8 @@ RUN if [ "${POETRY_VERSION}" != "none" ]; then su vscode -c "umask 0002 && pip3 
 RUN rm -f /etc/apt/sources.list.d/yarn.list && \
     apt update -qy && \
     apt install -qy --no-install-recommends \
-        git
+        git \
+        libgdal-dev \
+        gdal-bin
 
 WORKDIR /openeo_argoworkflows_executor

--- a/openeo_argoworkflows/executor/.devcontainer/Dockerfile
+++ b/openeo_argoworkflows/executor/.devcontainer/Dockerfile
@@ -2,6 +2,7 @@ ARG VARIANT="3.11-bookworm"
 FROM mcr.microsoft.com/devcontainers/python:1-${VARIANT} as devcontainer
 
 ENV POETRY_VIRTUALENVS_IN_PROJECT 1
+ENV POETRY_EXPERIMENTAL_SYSTEM_GIT_CLIENT 1
 
 # Poetry
 ARG POETRY_VERSION="1.8.3"
@@ -12,13 +13,6 @@ RUN rm -f /etc/apt/sources.list.d/yarn.list && \
     apt install -qy --no-install-recommends \
         git \
         libgdal-dev \
-        gdal-bin \
-        openssh-client
-
-RUN mkdir -p /home/vscode/.ssh && \
-    ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> /home/vscode/.ssh/known_hosts && \
-    chown -R vscode:vscode /home/vscode/.ssh && \
-    chmod 700 /home/vscode/.ssh && \
-    chmod 600 /home/vscode/.ssh/known_hosts
+        gdal-bin
 
 WORKDIR /openeo_argoworkflows_executor

--- a/openeo_argoworkflows/executor/.devcontainer/Dockerfile
+++ b/openeo_argoworkflows/executor/.devcontainer/Dockerfile
@@ -12,6 +12,13 @@ RUN rm -f /etc/apt/sources.list.d/yarn.list && \
     apt install -qy --no-install-recommends \
         git \
         libgdal-dev \
-        gdal-bin
+        gdal-bin \
+        openssh-client
+
+RUN mkdir -p /home/vscode/.ssh && \
+    ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> /home/vscode/.ssh/known_hosts && \
+    chown -R vscode:vscode /home/vscode/.ssh && \
+    chmod 700 /home/vscode/.ssh && \
+    chmod 600 /home/vscode/.ssh/known_hosts
 
 WORKDIR /openeo_argoworkflows_executor

--- a/openeo_argoworkflows/executor/.devcontainer/Dockerfile
+++ b/openeo_argoworkflows/executor/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-ARG VARIANT="3.11-bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT} as devcontainer
+ARG VARIANT="3.11-bookworm"
+FROM mcr.microsoft.com/devcontainers/python:1-${VARIANT} as devcontainer
 
 ENV POETRY_VIRTUALENVS_IN_PROJECT 1
 

--- a/openeo_argoworkflows/executor/.devcontainer/Dockerfile
+++ b/openeo_argoworkflows/executor/.devcontainer/Dockerfile
@@ -7,7 +7,8 @@ ENV POETRY_VIRTUALENVS_IN_PROJECT 1
 ARG POETRY_VERSION="1.8.3"
 RUN if [ "${POETRY_VERSION}" != "none" ]; then su vscode -c "umask 0002 && pip3 install poetry==${POETRY_VERSION}"; fi
 
-RUN apt update -qy && \
+RUN rm -f /etc/apt/sources.list.d/yarn.list && \
+    apt update -qy && \
     apt install -qy --no-install-recommends \
         git
 

--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/executor.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/executor.py
@@ -67,10 +67,23 @@ def prepare_graphs(process_graph: OpenEOProcessGraph):
 
 
 def _is_cwl_job(pg_data: dict) -> bool:
-    """Check if the process graph is a CWL job (contains run_cwl as a node)."""
+    """Check if the process graph is a CWL job.
+
+    Detects either:
+    - process_id = "run_cwl" (legacy)
+    - process_id = "run_udf" with runtime argument == "EOAP-CWL" (case-insensitive)
+    """
     for node_id, node in pg_data.items():
-        if isinstance(node, dict) and node.get("process_id") == "run_cwl":
+        if not isinstance(node, dict):
+            continue
+        pid = node.get("process_id")
+        if pid == "run_cwl":
             return True
+        if pid == "run_udf":
+            args = node.get("arguments", {})
+            runtime = args.get("runtime", "")
+            if isinstance(runtime, str) and runtime.lower() == "eoap-cwl":
+                return True
     return False
 
 

--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/cwl.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/cwl.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
 
-__all__ = ["run_cwl"]
+__all__ = ["run_cwl", "run_udf"]
 
 logger = logging.getLogger(__name__)
 
@@ -277,3 +277,31 @@ def run_cwl(
             "collected_files": collected_files,
             "status": "completed",
         }
+
+def run_udf(
+    data=None,
+    udf: str = "",
+    runtime: str = "",
+    version: Optional[str] = None,
+    context: Optional[dict] = None,
+    **kwargs,
+):
+    """run_udf handler for EOAP-CWL runtime.   
+
+    Maps run_udf parameters to run_cwl:
+      udf     -> cwl  (the CWL document or URL)
+      context -> inputs (CWL input key-value pairs)
+
+    The `data` parameter is ignored — CWL workflows receive
+    pre-staged inputs via `context`, not a datacube.
+    """
+    if runtime.lower() != "eoap-cwl":
+        raise RuntimeError(
+            f"Unsupported runtime '{runtime}'. This backend only supports 'EOAP-CWL'."
+        )
+
+    return run_cwl(
+        cwl=udf,
+        inputs=context or {},
+        **kwargs,
+    )

--- a/openeo_argoworkflows/executor/poetry.lock
+++ b/openeo_argoworkflows/executor/poetry.lock
@@ -1877,12 +1877,12 @@ tqdm = ["tqdm"]
 
 [[package]]
 name = "gdal"
-version = "3.12.2"
+version = "3.6.2"
 description = "GDAL: Geospatial Data Abstraction Library"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "gdal-3.12.2.tar.gz", hash = "sha256:a5afa8e55a19b296a004a15d38fe3ad60cc380f1f090e2aab5d35331008c970f"},
+    {file = "GDAL-3.6.2.tar.gz", hash = "sha256:a167cde1813707d91a938dad1a22f280f5ad28c45980d42e948fb8c59f890f5a"},
 ]
 
 [package.extras]

--- a/openeo_argoworkflows/executor/tests/test_cwl.py
+++ b/openeo_argoworkflows/executor/tests/test_cwl.py
@@ -108,14 +108,16 @@ class TestCreateCwlStac:
             assert collection["id"] == "test-job-123"
             assert collection["type"] == "Collection"
 
-            # Check items were created
-            items_file = os.path.join(stac_path, "inline_items.csv")
-            assert os.path.exists(items_file)
-            with open(items_file) as f:
-                lines = [line.strip() for line in f if line.strip()]
-            assert len(lines) == 2
+            # Check items were created (one JSON file per output file in items/)
+            items_dir = os.path.join(stac_path, "items")
+            assert os.path.isdir(items_dir)
+            item_files = [f for f in os.listdir(items_dir) if f.endswith(".json")]
+            assert len(item_files) == 2
 
-            item1 = json.loads(lines[0])
+            with open(os.path.join(items_dir, "output.json")) as f:
+                item1 = json.load(f)
             assert item1["type"] == "Feature"
             assert item1["collection"] == "test-job-123"
             assert "output.txt" in item1["assets"]
+
+


### PR DESCRIPTION
- Populate get_udf_runtimes() with EOAP-CWL entry (API Patch)
- Add run_udf process spec json (auto loaded by app.py)
- Extend _is_cwl_job() to detect run_udf with runtime=EOAP-CWL
- Add run_udf() shim in cwl.py by mapping udf to cwl, context to inputs