### PR TITLE
feat(run_udf): dynamic context generation from CWL inputs block (#127)

### DIFF
--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/cwl.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/cwl.py
@@ -18,6 +18,14 @@ logger = logging.getLogger(__name__)
 DEFAULT_MAX_RAM = "16G"
 DEFAULT_MAX_CORES = 8
 
+# Issue #127: CWL inputs that can be auto-filled from the openEO execution
+# environment. Only injected when the CWL document actually declares an input
+# of that name AND the user did not supply it in `context`.
+_ENV_AUTO_INPUTS = {
+    "job_id": "OPENEO_JOB_ID",
+    "user_id": "OPENEO_USER_ID",
+}
+
 
 def _is_url(value: str) -> bool:
     """Check if a string looks like a URL."""
@@ -104,6 +112,113 @@ def _validate_cwl(cwl_path: Path) -> dict:
             errors.append(line.strip())
 
     return {"valid": False, "errors": errors}
+
+def _load_cwl_doc(cwl_path: Path) -> dict:
+    """Load a CWL file as a dict, resolving $graph packages to the run entry.
+
+    For a $graph package, returns the tool/workflow the executor actually runs
+    (the entry whose id is 'main' / '#main' — see _resolve_cwl_arg), falling
+    back to the first CommandLineTool/Workflow, then the first entry. Returns
+    {} if the document can't be parsed into a mapping.
+    """
+    import yaml
+
+    doc = yaml.safe_load(cwl_path.read_text())
+    if not isinstance(doc, dict):
+        return {}
+    if "$graph" in doc:
+        graph = doc.get("$graph") or []
+        entries = [e for e in graph if isinstance(e, dict)]
+        for entry in entries:
+            if str(entry.get("id", "")).lstrip("#") == "main":
+                return entry
+        for entry in entries:
+            if entry.get("class") in ("CommandLineTool", "Workflow", "ExpressionTool"):
+                return entry
+        return entries[0] if entries else {}
+    return doc
+
+
+def _input_is_optional(type_val) -> bool:
+    """Return True if a CWL input type marks the input as optional/nullable.
+
+    Optional forms: a 'type?' string shorthand, or a union list containing
+    'null' (e.g. ['null', 'string']).
+    """
+    if isinstance(type_val, str):
+        return type_val.endswith("?")
+    if isinstance(type_val, list):
+        return "null" in type_val
+    return False
+
+
+def _parse_cwl_inputs(cwl_doc: dict) -> dict:
+    """Parse a CWL `inputs:` block into a normalised dict (issue #127).
+
+    Handles both the mapping form ({name: type | {type, default}}) and the
+    list form ([{id, type, default}, ...]). Returns:
+        {name: {type, default, has_default, optional, required}}
+    An input is `required` when it is neither optional (nullable / '?' / union
+    with null) nor has a default.
+    """
+    inputs_block = (cwl_doc or {}).get("inputs")
+    if isinstance(inputs_block, dict):
+        items = list(inputs_block.items())
+    elif isinstance(inputs_block, list):
+        items = [(e.get("id"), e) for e in inputs_block if isinstance(e, dict)]
+    else:
+        return {}
+
+    result = {}
+    for name, spec in items:
+        if not name:
+            continue
+        if isinstance(spec, dict):
+            type_val = spec.get("type")
+            has_default = "default" in spec
+            default = spec.get("default")
+        else:
+            type_val = spec
+            has_default = False
+            default = None
+        optional = _input_is_optional(type_val) or has_default
+        result[name] = {
+            "type": type_val,
+            "default": default,
+            "has_default": has_default,
+            "optional": optional,
+            "required": not optional,
+        }
+    return result
+
+
+def _auto_wire_inputs(cwl_inputs: dict, inputs: dict) -> dict:
+    """Fill declared CWL inputs from the openEO execution env (issue #127).
+
+    Declaration-gated: only inputs the CWL actually declares are touched.
+    User-supplied `context` values always win, and env vars that are absent
+    are skipped. Returns a new dict; the caller's `inputs` is not mutated.
+    """
+    wired = dict(inputs)
+    for name, env_key in _ENV_AUTO_INPUTS.items():
+        if name not in cwl_inputs or name in wired:
+            continue
+        value = os.environ.get(env_key)
+        if value is None:
+            continue
+        wired[name] = value
+        logger.info(f"Auto-wired CWL input '{name}' from {env_key}")
+    return wired
+
+
+def _missing_required_inputs(cwl_inputs: dict, inputs: dict) -> list:
+    """Return required CWL inputs (no default, not optional) still unprovided."""
+    return [
+        name
+        for name, spec in cwl_inputs.items()
+        if spec.get("required") and name not in inputs
+    ]
+
 
 def _find_stac_root(directory: Path) -> Optional[Path]:
     """Search for a STAC root file in the calrissian output directory.
@@ -233,6 +348,23 @@ def run_cwl(
 
         if validate_only:
             return validation
+
+        # Issue #127: parse the CWL inputs block and auto-wire known openEO
+        # context values (job_id, user_id) for inputs the document declares but
+        # the user did not supply. Declaration-gated and non-fatal — a parse
+        # failure must never break an otherwise-valid job.
+        try:
+            cwl_inputs = _parse_cwl_inputs(_load_cwl_doc(cwl_path))
+            if cwl_inputs:
+                inputs = _auto_wire_inputs(cwl_inputs, inputs)
+                missing = _missing_required_inputs(cwl_inputs, inputs)
+                if missing:
+                    logger.warning(
+                        "CWL inputs required but not provided (no default): "
+                        f"{missing}. Add them to the run_udf 'context'."
+                    )
+        except Exception as e:
+            logger.warning(f"Could not parse CWL inputs for auto-wiring (#127): {e}")
 
         # Write inputs file
         inputs_path = _write_inputs(inputs, work_dir)

--- a/openeo_argoworkflows/executor/tests/test_cwl_inputs.py
+++ b/openeo_argoworkflows/executor/tests/test_cwl_inputs.py
@@ -1,0 +1,208 @@
+"""Tests for issue #127 — dynamic CWL context generation from the CWL inputs block.
+
+TDD: tests written before implementation.
+
+Covers the pure helpers added to cwl.py:
+  - _load_cwl_doc        : YAML-load a CWL file, resolving $graph to the #main tool
+  - _parse_cwl_inputs    : normalise the CWL `inputs:` block (mapping or list form)
+  - _auto_wire_inputs    : fill declared inputs from openEO env (job_id, user_id)
+  - _missing_required_inputs : list required-and-unprovided inputs (for the warning)
+
+The module is loaded standalone (like test_run_udf.py) to avoid pulling in the
+executor's heavy dependency tree.
+"""
+
+import importlib.util
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_cwl_spec = importlib.util.spec_from_file_location(
+    "cwl",
+    Path(__file__).parent.parent
+    / "openeo_argoworkflows_executor/extra_processes/process_implementations/cwl.py",
+)
+_cwl = importlib.util.module_from_spec(_cwl_spec)
+_cwl_spec.loader.exec_module(_cwl)
+
+
+class TestParseCwlInputs:
+    """Normalising the CWL inputs block into {name: {type, optional, required, ...}}."""
+
+    def test_mapping_form_simple_string(self):
+        parsed = _cwl._parse_cwl_inputs({"inputs": {"message": "string"}})
+        assert "message" in parsed
+        assert parsed["message"]["required"] is True
+        assert parsed["message"]["optional"] is False
+
+    def test_mapping_form_with_default_is_not_required(self):
+        parsed = _cwl._parse_cwl_inputs(
+            {"inputs": {"count": {"type": "int", "default": 5}}}
+        )
+        assert parsed["count"]["has_default"] is True
+        assert parsed["count"]["required"] is False
+
+    def test_optional_via_question_mark(self):
+        parsed = _cwl._parse_cwl_inputs({"inputs": {"opt": "string?"}})
+        assert parsed["opt"]["optional"] is True
+        assert parsed["opt"]["required"] is False
+
+    def test_optional_via_null_union(self):
+        parsed = _cwl._parse_cwl_inputs(
+            {"inputs": {"nullable": {"type": ["null", "string"]}}}
+        )
+        assert parsed["nullable"]["optional"] is True
+        assert parsed["nullable"]["required"] is False
+
+    def test_list_form(self):
+        parsed = _cwl._parse_cwl_inputs(
+            {
+                "inputs": [
+                    {"id": "message", "type": "string"},
+                    {"id": "count", "type": "int", "default": 5},
+                ]
+            }
+        )
+        assert parsed["message"]["required"] is True
+        assert parsed["count"]["required"] is False
+
+    def test_missing_inputs_block_returns_empty(self):
+        assert _cwl._parse_cwl_inputs({"class": "CommandLineTool"}) == {}
+        assert _cwl._parse_cwl_inputs({}) == {}
+
+
+class TestLoadCwlDoc:
+    """Loading a CWL file, including $graph packages."""
+
+    def _write(self, tmp_path, text):
+        p = tmp_path / "workflow.cwl"
+        p.write_text(text)
+        return p
+
+    def test_plain_tool(self, tmp_path):
+        p = self._write(
+            tmp_path,
+            "class: CommandLineTool\ncwlVersion: v1.2\ninputs:\n  msg: string\noutputs: {}\n",
+        )
+        doc = _cwl._load_cwl_doc(p)
+        assert doc.get("class") == "CommandLineTool"
+        assert "msg" in _cwl._parse_cwl_inputs(doc)
+
+    def test_graph_resolves_main_entry(self, tmp_path):
+        p = self._write(
+            tmp_path,
+            (
+                "cwlVersion: v1.2\n"
+                "$graph:\n"
+                "  - id: helper\n"
+                "    class: CommandLineTool\n"
+                "    inputs:\n      helper_in: string\n    outputs: {}\n"
+                "  - id: main\n"
+                "    class: Workflow\n"
+                "    inputs:\n      main_in: string\n    outputs: {}\n    steps: {}\n"
+            ),
+        )
+        doc = _cwl._load_cwl_doc(p)
+        parsed = _cwl._parse_cwl_inputs(doc)
+        assert "main_in" in parsed
+        assert "helper_in" not in parsed
+
+
+class TestAutoWireInputs:
+    """Filling declared inputs from openEO execution env — declaration-gated."""
+
+    def test_wires_job_id_and_user_id_when_declared(self):
+        cwl_inputs = _cwl._parse_cwl_inputs(
+            {"inputs": {"job_id": "string", "user_id": "string"}}
+        )
+        with patch.dict(os.environ, {"OPENEO_JOB_ID": "job-abc", "OPENEO_USER_ID": "user-xyz"}):
+            wired = _cwl._auto_wire_inputs(cwl_inputs, {})
+        assert wired["job_id"] == "job-abc"
+        assert wired["user_id"] == "user-xyz"
+
+    def test_does_not_wire_input_not_declared_by_cwl(self):
+        cwl_inputs = _cwl._parse_cwl_inputs({"inputs": {"message": "string"}})
+        with patch.dict(os.environ, {"OPENEO_JOB_ID": "job-abc"}):
+            wired = _cwl._auto_wire_inputs(cwl_inputs, {})
+        assert "job_id" not in wired
+
+    def test_user_supplied_value_wins(self):
+        cwl_inputs = _cwl._parse_cwl_inputs({"inputs": {"job_id": "string"}})
+        with patch.dict(os.environ, {"OPENEO_JOB_ID": "env-job"}):
+            wired = _cwl._auto_wire_inputs(cwl_inputs, {"job_id": "user-job"})
+        assert wired["job_id"] == "user-job"
+
+    def test_skips_when_env_absent(self):
+        cwl_inputs = _cwl._parse_cwl_inputs({"inputs": {"job_id": "string"}})
+        with patch.dict(os.environ, {}, clear=True):
+            wired = _cwl._auto_wire_inputs(cwl_inputs, {})
+        assert "job_id" not in wired
+
+    def test_does_not_mutate_caller_inputs(self):
+        cwl_inputs = _cwl._parse_cwl_inputs({"inputs": {"job_id": "string"}})
+        original = {}
+        with patch.dict(os.environ, {"OPENEO_JOB_ID": "job-abc"}):
+            _cwl._auto_wire_inputs(cwl_inputs, original)
+        assert original == {}
+
+
+class TestMissingRequiredInputs:
+    """Listing required-and-unprovided inputs for the user-facing warning."""
+
+    def test_lists_required_missing(self):
+        cwl_inputs = _cwl._parse_cwl_inputs({"inputs": {"aoi": "string"}})
+        assert _cwl._missing_required_inputs(cwl_inputs, {}) == ["aoi"]
+
+    def test_default_input_not_listed(self):
+        cwl_inputs = _cwl._parse_cwl_inputs(
+            {"inputs": {"count": {"type": "int", "default": 1}}}
+        )
+        assert _cwl._missing_required_inputs(cwl_inputs, {}) == []
+
+    def test_optional_input_not_listed(self):
+        cwl_inputs = _cwl._parse_cwl_inputs({"inputs": {"opt": "string?"}})
+        assert _cwl._missing_required_inputs(cwl_inputs, {}) == []
+
+    def test_provided_input_not_listed(self):
+        cwl_inputs = _cwl._parse_cwl_inputs({"inputs": {"aoi": "string"}})
+        assert _cwl._missing_required_inputs(cwl_inputs, {"aoi": "POLYGON(...)"}) == []
+
+
+class TestRunCwlAutoWiringIntegration:
+    """Drive run_cwl() far enough to prove the parsing/auto-wiring is wired in.
+
+    Validation is stubbed and execution is short-circuited at the _write_inputs
+    boundary, where we capture the final inputs dict that would be handed to
+    Calrissian.
+    """
+
+    _INLINE_CWL = (
+        "class: CommandLineTool\n"
+        "cwlVersion: v1.2\n"
+        "baseCommand: echo\n"
+        "inputs:\n  job_id: string\n"
+        "outputs: {}\n"
+    )
+
+    def test_run_cwl_injects_declared_job_id_from_env(self, tmp_path, monkeypatch):
+        captured = {}
+
+        class _Stop(Exception):
+            pass
+
+        def _capture(inputs, work_dir):
+            captured.update(inputs)
+            raise _Stop()
+
+        monkeypatch.setenv("OPENEO_RESULTS_PATH", str(tmp_path / "results"))
+        monkeypatch.setenv("OPENEO_USER_WORKSPACE", str(tmp_path / "ws"))
+        monkeypatch.setenv("OPENEO_JOB_ID", "job-int-123")
+        monkeypatch.setattr(_cwl, "_validate_cwl", lambda p: {"valid": True, "errors": []})
+        monkeypatch.setattr(_cwl, "_write_inputs", _capture)
+
+        with pytest.raises(_Stop):
+            _cwl.run_cwl(cwl=self._INLINE_CWL, inputs={})
+
+        assert captured.get("job_id") == "job-int-123"


### PR DESCRIPTION
Closes #127.

## What

Parse the CWL `inputs:` block at execution time and auto-wire openEO context values for inputs the CWL declares but the user did not supply — reducing the manual `context` burden and turning cryptic Calrissian failures into a clear, named warning.

New pure helpers in `cwl.py`:
- `_load_cwl_doc` — YAML-load the resolved CWL, resolving `$graph` packages to the `#main` entry
- `_parse_cwl_inputs` — normalise both the mapping and list forms to `{name: {type, default, has_default, optional, required}}`
- `_auto_wire_inputs` — fill `job_id`/`user_id` from `OPENEO_JOB_ID`/`OPENEO_USER_ID`; **declaration-gated**, user `context` always wins, absent env vars skipped, caller dict not mutated
- `_missing_required_inputs` — drives a warning naming each required-but-unprovided input

Wired into `run_cwl()` after validation, **non-fatal**: a parse failure logs a warning and never breaks an otherwise-valid job.

## Acceptance criteria
- [x] CWL `inputs:` block parsed (URL/inline, mapping + list + `$graph`)
- [x] `openeo_data` / `job_id` / `user_id` auto-injected without `context` (`openeo_data` via existing #104 path; `job_id`/`user_id` new, declaration-gated)
- [x] User-supplied `context` overrides auto-inferred values
- [x] Missing required inputs → clear log warning naming the parameter
- [x] Existing CWL jobs (explicit `context`) unchanged
- [x] Unit tests: auto-injection, user override, missing-required warning

## Tests
`test_cwl_inputs.py` — 18 unit + 1 integration through `run_cwl` (26 pass with `test_run_udf.py`). `py_compile` clean.

## Out of scope (follow-up)
- Exposing CWL inputs to the Web Editor at submission time for `context` pre-fill (needs API + editor changes — separate issue)
- Auto-inferring spatial/temporal extent from the process graph

## Testing note
Executor change — reaches the live backend only once `:eurac-main` rebuilds on merge; `kubectl rollout restart` the executor afterwards.