### PR TITLE
feat(api): CWL input schema endpoint for Web Editor context pre-fill (#129)

### DIFF
--- a/openeo_argoworkflows/api/openeo_argoworkflows_api/app.py
+++ b/openeo_argoworkflows/api/openeo_argoworkflows_api/app.py
@@ -2,10 +2,12 @@
 import json
 import uuid
 from pathlib import Path
+from typing import Optional
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
 from starlette.responses import RedirectResponse
 
 from openeo_fastapi.client.psql.engine import get
@@ -145,6 +147,46 @@ def s3_proxy_download(job_id: uuid.UUID, filename: str):
     return StreamingResponse(body.iter_chunks(), media_type=content_type, headers=headers)
 
 
+class CwlInspectRequest(BaseModel):
+    """Request body for the CWL input-schema endpoint (#129).
+
+    Provide exactly one of `url` (fetched over http/https) or `cwl` (inline doc).
+    """
+    url: Optional[str] = None
+    cwl: Optional[str] = None
+
+
+def cwl_inputs_inspect(body: CwlInspectRequest):
+    """Return a CWL document's input schema for the Web Editor (#129).
+
+    Parses the `inputs:` block and flags inputs the executor auto-fills
+    (`job_id`/`user_id`/`openeo_data`, see #127) so the editor can render a
+    `context` form and hide the auto-filled fields.
+    """
+    from openeo_argoworkflows_api import cwl_inputs as _cwl_inputs
+
+    has_url, has_cwl = bool(body.url), bool(body.cwl)
+    if has_url == has_cwl:
+        raise HTTPException(
+            status_code=400, detail="Provide exactly one of 'url' or 'cwl'."
+        )
+
+    try:
+        text = _cwl_inputs.fetch_cwl_text(body.url) if has_url else body.cwl
+        doc = _cwl_inputs.load_cwl_doc(text)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Failed to fetch/parse CWL: {e}")
+
+    if not doc:
+        raise HTTPException(
+            status_code=400, detail="CWL document is empty or not a valid mapping."
+        )
+
+    return {"inputs": _cwl_inputs.build_input_schema(doc)}
+
+
 def redirect_wellknown():
     return RedirectResponse("/.well-known/openeo")
 
@@ -174,6 +216,14 @@ api.app.router.add_api_route(
     response_model=None,
     methods=["GET", "HEAD"],
     endpoint=s3_proxy_download,
+)
+
+api.app.router.add_api_route(
+    name="cwl_inputs_inspect",
+    path=f"{client.settings.OPENEO_PREFIX}/cwl/inputs",
+    response_model=None,
+    methods=["POST"],
+    endpoint=cwl_inputs_inspect,
 )
 
 app = api.app

--- a/openeo_argoworkflows/api/openeo_argoworkflows_api/cwl_inputs.py
+++ b/openeo_argoworkflows/api/openeo_argoworkflows_api/cwl_inputs.py
@@ -1,0 +1,119 @@
+"""Parse a CWL document's `inputs:` block into a schema for the Web Editor (#129).
+
+API-side counterpart to the executor's #127 auto-wiring. The executor fills
+`job_id`/`user_id`/`openeo_data` at run time; here we expose the same input
+schema *before* submission so the editor can render a `context` form and flag
+the inputs the backend fills automatically.
+
+NOTE: this duplicates the pure parsing logic in the executor's
+`extra_processes/process_implementations/cwl.py` (#127). The two images have
+separate build contexts and cannot share a module today — keep them in sync.
+Tracked as tech debt: unify into a shared package once a dev env exists.
+"""
+
+import urllib.request
+
+import yaml
+
+# CWL inputs the executor auto-fills from the openEO execution context (#127).
+# The editor uses these flags to hide/grey the corresponding fields.
+AUTO_FILLED_INPUTS = ("job_id", "user_id", "openeo_data")
+
+# Cap remote CWL downloads so a hostile/huge URL can't exhaust memory.
+_MAX_CWL_BYTES = 1 * 1024 * 1024  # 1 MiB
+
+
+def fetch_cwl_text(url: str, timeout: int = 15) -> str:
+    """Download a CWL document over http(s). Patched out in tests.
+
+    Only http/https are allowed (basic SSRF guard — no file://, ftp://, etc.).
+    """
+    scheme = url.split("://", 1)[0].lower() if "://" in url else ""
+    if scheme not in ("http", "https"):
+        raise ValueError(f"Unsupported URL scheme '{scheme}': only http/https allowed")
+    with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310 (scheme checked)
+        return resp.read(_MAX_CWL_BYTES + 1).decode("utf-8")
+
+
+def load_cwl_doc(text: str) -> dict:
+    """Parse CWL text to a dict, resolving $graph packages to the run entry.
+
+    For a $graph package, returns the tool/workflow the executor would run
+    (the entry whose id is 'main' / '#main'), falling back to the first
+    CommandLineTool/Workflow, then the first entry. Returns {} if the document
+    can't be parsed into a mapping.
+    """
+    doc = yaml.safe_load(text)
+    if not isinstance(doc, dict):
+        return {}
+    if "$graph" in doc:
+        entries = [e for e in (doc.get("$graph") or []) if isinstance(e, dict)]
+        for entry in entries:
+            if str(entry.get("id", "")).lstrip("#") == "main":
+                return entry
+        for entry in entries:
+            if entry.get("class") in ("CommandLineTool", "Workflow", "ExpressionTool"):
+                return entry
+        return entries[0] if entries else {}
+    return doc
+
+
+def _input_is_optional(type_val) -> bool:
+    """True if a CWL input type marks the input optional/nullable.
+
+    Optional forms: a 'type?' shorthand, or a union list containing 'null'.
+    """
+    if isinstance(type_val, str):
+        return type_val.endswith("?")
+    if isinstance(type_val, list):
+        return "null" in type_val
+    return False
+
+
+def parse_cwl_inputs(cwl_doc: dict) -> dict:
+    """Normalise a CWL `inputs:` block (mapping or list form) to:
+
+        {name: {type, default, has_default, optional, required}}
+
+    Required = neither optional (nullable / '?' / null-union) nor defaulted.
+    """
+    inputs_block = (cwl_doc or {}).get("inputs")
+    if isinstance(inputs_block, dict):
+        items = list(inputs_block.items())
+    elif isinstance(inputs_block, list):
+        items = [(e.get("id"), e) for e in inputs_block if isinstance(e, dict)]
+    else:
+        return {}
+
+    result = {}
+    for name, spec in items:
+        if not name:
+            continue
+        if isinstance(spec, dict):
+            type_val = spec.get("type")
+            has_default = "default" in spec
+            default = spec.get("default")
+        else:
+            type_val = spec
+            has_default = False
+            default = None
+        optional = _input_is_optional(type_val) or has_default
+        result[name] = {
+            "type": type_val,
+            "default": default,
+            "has_default": has_default,
+            "optional": optional,
+            "required": not optional,
+        }
+    return result
+
+
+def build_input_schema(cwl_doc: dict) -> dict:
+    """Parse inputs and flag the ones the executor auto-fills (#127).
+
+    Returns {name: {..parse fields.., autofilled: bool}}.
+    """
+    parsed = parse_cwl_inputs(cwl_doc)
+    for name, spec in parsed.items():
+        spec["autofilled"] = name in AUTO_FILLED_INPUTS
+    return parsed

--- a/openeo_argoworkflows/api/tests/test_cwl_inputs.py
+++ b/openeo_argoworkflows/api/tests/test_cwl_inputs.py
@@ -1,0 +1,119 @@
+"""Tests for #129 — API-side CWL input schema endpoint + parser.
+
+TDD: written before the endpoint exists.
+
+  - parser unit tests (mirror executor #127, plus the `autofilled` flag)
+  - HTTP-level tests via TestClient against POST {OPENEO_PREFIX}/cwl/inputs
+"""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from openeo_argoworkflows_api import cwl_inputs
+from openeo_argoworkflows_api.app import app as app_api
+from openeo_argoworkflows_api.app import client
+
+PREFIX = client.settings.OPENEO_PREFIX
+ENDPOINT = f"{PREFIX}/cwl/inputs"
+
+_INLINE_CWL = (
+    "cwlVersion: v1.2\n"
+    "class: CommandLineTool\n"
+    "baseCommand: echo\n"
+    "inputs:\n"
+    "  aoi: string\n"
+    "  count:\n    type: int\n    default: 1\n"
+    "  opt: string?\n"
+    "  job_id: string\n"
+    "outputs: {}\n"
+)
+
+_GRAPH_CWL = (
+    "cwlVersion: v1.2\n"
+    "$graph:\n"
+    "  - id: helper\n    class: CommandLineTool\n    inputs:\n      helper_in: string\n    outputs: {}\n"
+    "  - id: main\n    class: Workflow\n    inputs:\n      main_in: string\n    outputs: {}\n    steps: {}\n"
+)
+
+
+class TestParser:
+    def test_required_vs_default_vs_optional(self):
+        parsed = cwl_inputs.parse_cwl_inputs(
+            {"inputs": {"a": "string", "b": {"type": "int", "default": 1}, "c": "string?"}}
+        )
+        assert parsed["a"]["required"] is True
+        assert parsed["b"]["required"] is False
+        assert parsed["c"]["optional"] is True
+
+    def test_list_form(self):
+        parsed = cwl_inputs.parse_cwl_inputs(
+            {"inputs": [{"id": "x", "type": "string"}, {"id": "y", "type": "int", "default": 2}]}
+        )
+        assert parsed["x"]["required"] is True
+        assert parsed["y"]["required"] is False
+
+    def test_null_union_is_optional(self):
+        parsed = cwl_inputs.parse_cwl_inputs({"inputs": {"n": {"type": ["null", "string"]}}})
+        assert parsed["n"]["optional"] is True
+
+    def test_missing_inputs_block(self):
+        assert cwl_inputs.parse_cwl_inputs({"class": "CommandLineTool"}) == {}
+
+    def test_load_graph_resolves_main(self):
+        doc = cwl_inputs.load_cwl_doc(_GRAPH_CWL)
+        parsed = cwl_inputs.parse_cwl_inputs(doc)
+        assert "main_in" in parsed and "helper_in" not in parsed
+
+    def test_build_schema_flags_autofilled(self):
+        doc = cwl_inputs.load_cwl_doc(_INLINE_CWL)
+        schema = cwl_inputs.build_input_schema(doc)
+        assert schema["job_id"]["autofilled"] is True
+        assert schema["aoi"]["autofilled"] is False
+
+    def test_fetch_rejects_non_http_scheme(self):
+        import pytest
+
+        with pytest.raises(ValueError):
+            cwl_inputs.fetch_cwl_text("file:///etc/passwd")
+
+
+class TestCwlInputsEndpoint:
+    client = TestClient(app_api)
+
+    def test_inline_cwl_returns_schema(self):
+        resp = self.client.post(ENDPOINT, json={"cwl": _INLINE_CWL})
+        assert resp.status_code == 200
+        inputs = resp.json()["inputs"]
+        assert inputs["aoi"]["required"] is True
+        assert inputs["aoi"]["autofilled"] is False
+        assert inputs["job_id"]["autofilled"] is True
+        assert inputs["count"]["required"] is False
+
+    def test_url_cwl_fetches_and_returns_schema(self):
+        with patch.object(cwl_inputs, "fetch_cwl_text", return_value=_INLINE_CWL) as m:
+            resp = self.client.post(ENDPOINT, json={"url": "https://example.com/tool.cwl"})
+        assert resp.status_code == 200
+        m.assert_called_once_with("https://example.com/tool.cwl")
+        assert "aoi" in resp.json()["inputs"]
+
+    def test_graph_cwl_over_http_returns_main_inputs(self):
+        resp = self.client.post(ENDPOINT, json={"cwl": _GRAPH_CWL})
+        assert resp.status_code == 200
+        assert "main_in" in resp.json()["inputs"]
+
+    def test_neither_url_nor_cwl_is_400(self):
+        resp = self.client.post(ENDPOINT, json={})
+        assert resp.status_code == 400
+
+    def test_both_url_and_cwl_is_400(self):
+        resp = self.client.post(ENDPOINT, json={"url": "https://x/y.cwl", "cwl": _INLINE_CWL})
+        assert resp.status_code == 400
+
+    def test_bad_scheme_url_is_400(self):
+        resp = self.client.post(ENDPOINT, json={"url": "file:///etc/passwd"})
+        assert resp.status_code == 400
+
+    def test_unparseable_cwl_is_400(self):
+        resp = self.client.post(ENDPOINT, json={"cwl": "::: not valid yaml ::: ["})
+        assert resp.status_code == 400


### PR DESCRIPTION
Part 1 of #129 (API). Follow-up to #127.

## What
`POST {OPENEO_PREFIX}/cwl/inputs` — given a CWL document (`url` or inline `cwl`), returns its `inputs:` schema so the Web Editor can render a `context` form **before** submission and flag the inputs the executor auto-fills (`job_id`/`user_id`/`openeo_data`, per #127).

Response:
```json
{ "inputs": {
    "aoi":    {"type":"string","required":true,"optional":false,"default":null,"autofilled":false},
    "job_id": {"type":"string","required":true,"optional":false,"default":null,"autofilled":true}
}}
```

- `cwl_inputs.py` — pure parser: `load_cwl_doc` (with `$graph` → `#main` resolution), `parse_cwl_inputs` (mapping + list forms, optional via `?`/null-union/default), `build_input_schema` (flags auto-filled). `fetch_cwl_text` restricts to http/https (SSRF guard) and caps size.
- `app.py` — `cwl_inputs_inspect` endpoint + route; exactly one of `url`/`cwl` required; fetch/parse errors → 400.

## Tests
`api/tests/test_cwl_inputs.py` — 7 parser unit + 7 HTTP-level (TestClient). All green. `py_compile` clean.

## Notes
- Mirrors #127's executor parser; the two images have separate build contexts so a shared module isn't possible today (kept in sync; tech-debt to unify once dev env exists).
- **Routing**: in-house nginx ingress `/openeo` prefix already covers this — no ingress change.
- **Deploy gotcha**: API deployment is `imagePullPolicy: IfNotPresent` on `:eurac-main` — after merge+rebuild, force a fresh pull (set `Always` or clear the cached node image); a rollout restart alone reuses the stale tag.
- **Hardening follow-up**: SSRF is limited to http/https + returns only the parsed `inputs:` block, but internal-IP filtering could be added later.

## Out of scope (next)
- Web Editor "Populate from CWL" button calling this endpoint (separate editor-repo change).