### PR TITLE
feat(auth): advertise openeo.eurac.edu/editor as OIDC redirect URL

### DIFF
--- a/openeo_argoworkflows/api/openeo_argoworkflows_api/auth.py
+++ b/openeo_argoworkflows/api/openeo_argoworkflows_api/auth.py
@@ -249,6 +249,7 @@ def get_credentials_oidc() -> Response:
                             "https://editor.openeo.cloud",
                             "https://editor.openeo.org",
                             "http://localhost:1410/",
+                            "https://openeo.eurac.edu/editor/",
                         ],
                         grant_types=[
                             GrantType.authorization_code_pkce,

--- a/openeo_argoworkflows/api/patches/openeo_fastapi_core.py
+++ b/openeo_argoworkflows/api/patches/openeo_fastapi_core.py
@@ -155,6 +155,7 @@ class OpenEOCore:
                                 "http://localhost:1410/",
                                 "http://10.8.244.73:8080/",
                                 "http://localhost:8080/",
+                                "https://openeo.eurac.edu/editor/",
                             ],
                             grant_types=[
                                 GrantType.authorization_code_pkce,


### PR DESCRIPTION
The self-hosted Web Editor (#129) at `https://openeo.eurac.edu/editor` prompts for a Client ID because its URL isn't in the `eurac` provider's default-client `redirect_urls`. Add it so the editor auto-selects `openeo-platform-default-client` (no manual prompt).

- `patches/openeo_fastapi_core.py` (live `/credentials/oidc` source) + `auth.py` kept in sync.

**Companion change required (Keycloak):** the `openeo-platform-default-client` in the EURAC `edp` realm must also list `https://openeo.eurac.edu/editor/` as a Valid Redirect URI, or the login redirect is rejected by Keycloak.