### PR TITLE
ci: publish :stable and :dev image tags for polaris migration

### DIFF
--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - eurac-main
+      - dev
     paths:
       - 'openeo_argoworkflows/api/**'
   workflow_dispatch:
@@ -38,8 +39,10 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha,prefix=
-            type=raw,value=latest
-            type=raw,value=eurac-main
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/eurac-main' }}
+            type=raw,value=eurac-main,enable=${{ github.ref == 'refs/heads/eurac-main' }}
+            type=raw,value=stable,enable=${{ github.ref == 'refs/heads/eurac-main' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/build-executor.yaml
+++ b/.github/workflows/build-executor.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - eurac-main
+      - dev
     paths:
       - 'Dockerfile.executor'
       - 'openeo_argoworkflows/executor/openeo_argoworkflows_executor/**'
@@ -41,8 +42,10 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha,prefix=
-            type=raw,value=latest
-            type=raw,value=eurac-main
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/eurac-main' }}
+            type=raw,value=eurac-main,enable=${{ github.ref == 'refs/heads/eurac-main' }}
+            type=raw,value=stable,enable=${{ github.ref == 'refs/heads/eurac-main' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
       - name: Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Adds branch-conditional image tags so the two polaris k3s environments can be fed independently ahead of Friday's microk8s→polaris cutover.

- `eurac-main` → `:stable` (plus existing `:latest` / `:eurac-main`)
- `dev` branch → `:dev`

The `enable=` conditions scope each tag to its branch, so a push to `dev` only updates `:dev` and can never clobber the production `:stable`/`:eurac-main` tags (the failure mode behind the 06-16 image-poisoning incident).

Both API and executor workflows updated identically. After merge: create the `dev` branch off `eurac-main` and dispatch the four builds.