### PR TITLE
feat(api): surface CWL enum symbols + doc in /cwl/inputs (#129)

### DIFF
--- a/openeo_argoworkflows/api/openeo_argoworkflows_api/cwl_inputs.py
+++ b/openeo_argoworkflows/api/openeo_argoworkflows_api/cwl_inputs.py
@@ -70,11 +70,53 @@ def _input_is_optional(type_val) -> bool:
     return False
 
 
+def _extract_enum_symbols(type_val):
+    """Return the list of enum symbols if `type_val` is (or wraps) a CWL enum.
+
+    Handles an inline enum record ({type: enum, symbols: [...]}), an enum nested
+    under a `type` key ({type: {type: enum, symbols: [...]}}), and a union list
+    ([null, {type: enum, ...}]). Returns None when there is no enum.
+    """
+    members = type_val if isinstance(type_val, list) else [type_val]
+    for member in members:
+        if not isinstance(member, dict):
+            continue
+        if member.get("type") == "enum" and isinstance(member.get("symbols"), list):
+            return list(member["symbols"])
+        inner = member.get("type")
+        if isinstance(inner, (dict, list)):
+            nested = _extract_enum_symbols(inner)
+            if nested is not None:
+                return nested
+    return None
+
+
+def _type_name(type_val):
+    """Best-effort short type name for display (e.g. 'enum', 'string', 'int')."""
+    if isinstance(type_val, list):
+        non_null = [t for t in type_val if t != "null"]
+        if len(non_null) == 1:
+            return _type_name(non_null[0])
+        return "union" if non_null else "null"
+    if isinstance(type_val, dict):
+        inner = type_val.get("type")
+        if inner == "enum":
+            return "enum"
+        if isinstance(inner, (dict, list)):
+            return _type_name(inner)
+        return inner
+    if isinstance(type_val, str):
+        return type_val.rstrip("?")
+    return None
+
+
 def parse_cwl_inputs(cwl_doc: dict) -> dict:
     """Normalise a CWL `inputs:` block (mapping or list form) to:
 
-        {name: {type, default, has_default, optional, required}}
+        {name: {type, enum, doc, default, has_default, optional, required}}
 
+    `enum` is the list of allowed values for enum-typed inputs (else None) and
+    `doc` is the input's human-readable description (else None).
     Required = neither optional (nullable / '?' / null-union) nor defaulted.
     """
     inputs_block = (cwl_doc or {}).get("inputs")
@@ -89,8 +131,17 @@ def parse_cwl_inputs(cwl_doc: dict) -> dict:
     for name, spec in items:
         if not name:
             continue
+        doc = None
         if isinstance(spec, dict):
-            type_val = spec.get("type")
+            doc = spec.get("doc")
+            if spec.get("type") == "enum" and "symbols" in spec:
+                # Inline enum type record written directly as the input value.
+                type_val = spec
+            elif "type" in spec:
+                # InputParameter wrapper: the real type is under `type`.
+                type_val = spec.get("type")
+            else:
+                type_val = spec
             has_default = "default" in spec
             default = spec.get("default")
         else:
@@ -99,7 +150,9 @@ def parse_cwl_inputs(cwl_doc: dict) -> dict:
             default = None
         optional = _input_is_optional(type_val) or has_default
         result[name] = {
-            "type": type_val,
+            "type": _type_name(type_val),
+            "enum": _extract_enum_symbols(type_val),
+            "doc": doc,
             "default": default,
             "has_default": has_default,
             "optional": optional,

--- a/openeo_argoworkflows/api/tests/test_cwl_inputs.py
+++ b/openeo_argoworkflows/api/tests/test_cwl_inputs.py
@@ -71,6 +71,75 @@ class TestParser:
         assert schema["job_id"]["autofilled"] is True
         assert schema["aoi"]["autofilled"] is False
 
+
+class TestEnumAndDoc:
+    """Surface CWL enum `symbols` (allowed values) and `doc` (description)."""
+
+    def test_inline_enum_record(self):
+        # polarization: {type: enum, symbols: [VV, VH]}
+        parsed = cwl_inputs.parse_cwl_inputs(
+            {"inputs": {"polarization": {"type": "enum", "symbols": ["VV", "VH"]}}}
+        )
+        assert parsed["polarization"]["enum"] == ["VV", "VH"]
+        assert parsed["polarization"]["type"] == "enum"
+        assert parsed["polarization"]["required"] is True
+
+    def test_enum_as_single_member_union_list(self):
+        # polarization:\n  - type: enum\n    symbols: [VV, VH]
+        parsed = cwl_inputs.parse_cwl_inputs(
+            {"inputs": {"polarization": [{"type": "enum", "symbols": ["VV", "VH"]}]}}
+        )
+        assert parsed["polarization"]["enum"] == ["VV", "VH"]
+
+    def test_nested_type_with_doc(self):
+        # sub_swath:\n  type: {type: enum, symbols: [...]}\n  doc: "..."
+        parsed = cwl_inputs.parse_cwl_inputs(
+            {
+                "inputs": {
+                    "sub_swath": {
+                        "type": {"type": "enum", "symbols": ["IW1", "IW2", "IW3"]},
+                        "doc": "Sub-swath identifier",
+                    }
+                }
+            }
+        )
+        assert parsed["sub_swath"]["enum"] == ["IW1", "IW2", "IW3"]
+        assert parsed["sub_swath"]["doc"] == "Sub-swath identifier"
+        assert parsed["sub_swath"]["type"] == "enum"
+
+    def test_doc_on_plain_input(self):
+        parsed = cwl_inputs.parse_cwl_inputs(
+            {"inputs": {"aoi": {"type": "string", "doc": "Area of interest (WKT)"}}}
+        )
+        assert parsed["aoi"]["doc"] == "Area of interest (WKT)"
+        assert parsed["aoi"]["type"] == "string"
+        assert parsed["aoi"]["enum"] is None
+
+    def test_nullable_enum_is_optional_and_keeps_symbols(self):
+        parsed = cwl_inputs.parse_cwl_inputs(
+            {"inputs": {"pol": {"type": ["null", {"type": "enum", "symbols": ["VV"]}]}}}
+        )
+        assert parsed["pol"]["enum"] == ["VV"]
+        assert parsed["pol"]["optional"] is True
+
+    def test_non_enum_has_null_enum_and_no_doc(self):
+        parsed = cwl_inputs.parse_cwl_inputs({"inputs": {"x": "string"}})
+        assert parsed["x"]["enum"] is None
+        assert parsed["x"]["doc"] is None
+
+    def test_schema_endpoint_shape_includes_enum_and_doc(self):
+        # build_input_schema must carry enum/doc through alongside autofilled
+        doc = cwl_inputs.load_cwl_doc(
+            "class: CommandLineTool\ncwlVersion: v1.2\nbaseCommand: echo\n"
+            "inputs:\n"
+            "  sub_swath:\n    type:\n      type: enum\n      symbols: [IW1, IW2]\n    doc: pick one\n"
+            "outputs: {}\n"
+        )
+        schema = cwl_inputs.build_input_schema(doc)
+        assert schema["sub_swath"]["enum"] == ["IW1", "IW2"]
+        assert schema["sub_swath"]["doc"] == "pick one"
+        assert schema["sub_swath"]["autofilled"] is False
+
     def test_fetch_rejects_non_http_scheme(self):
         import pytest
 


### PR DESCRIPTION
Enhancement to the #129 endpoint. Returns `enum` (allowed values) and `doc` (description) per input so the Web Editor can prefill enums with a valid value and show guidance. Handles inline enum records, enum nested under `type`, and nullable/union enum lists. `type` normalised to a short name. 7 new tests, 21 total pass. Pairs with the editor change in the fork.