### PR TITLE
feat(cwl): upload CWL/EOAP outputs to S3 (parity with save_result)

### DIFF
--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/cli.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/cli.py
@@ -201,25 +201,10 @@ def execute(process_graph, user_profile, dask_profile):
                 ds.close()
 
             # Upload result files to S3 and rewrite STAC item hrefs
-            from openeo_argoworkflows_executor.extra_processes.process_implementations.s3 import upload_to_s3, is_s3_configured
-            if is_s3_configured():
-                import glob as _glob
-                for item_json in _glob.glob(f"{stac_path}/items/*.json"):
-                    with open(item_json, "r") as f:
-                        item = json.load(f)
-                    changed = False
-                    for asset in item.get("assets", {}).values():
-                        href = asset.get("href", "")
-                        if href and os.path.isfile(href):
-                            s3_uri = upload_to_s3(href)
-                            if s3_uri != href:
-                                asset["href"] = s3_uri
-                                changed = True
-                                logger.info(f"Uploaded {href} → {s3_uri}")
-                    if changed:
-                        with open(item_json, "w") as f:
-                            json.dump(item, f)
-                        logger.info(f"Patched STAC item hrefs in {item_json}")
+            from openeo_argoworkflows_executor.extra_processes.process_implementations.s3 import upload_stac_item_assets
+            n_uploaded = upload_stac_item_assets(f"{stac_path}/items")
+            if n_uploaded:
+                logger.info(f"Uploaded {n_uploaded} result asset(s) to S3")
 
             # POST collection to STAC API
             collection_file = f"{stac_path}/{job_id}.json"

--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/cwl.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/cwl.py
@@ -513,6 +513,21 @@ def run_cwl(
                     with open(item_file, "w") as f:
                         json.dump(item_dict, f, indent=2)
 
+            # Upload result assets to S3 and rewrite the STAC item hrefs to
+            # s3:// URIs — parity with the regular save_result path so CWL/EOAP
+            # outputs land in the object store too. No-op if S3 isn't configured;
+            # individual upload failures fall back to the local href.
+            try:
+                from openeo_argoworkflows_executor.extra_processes.process_implementations.s3 import (
+                    upload_stac_item_assets,
+                )
+
+                n_uploaded = upload_stac_item_assets(items_dir)
+                if n_uploaded:
+                    logger.info(f"Uploaded {n_uploaded} CWL output asset(s) to S3")
+            except Exception as e:
+                logger.warning(f"S3 upload of CWL outputs skipped due to error: {e}")
+
             logger.info(f"CWL produced STAC root ({stac_root.name}) - restructured to {stac_path}")
             collected_files = [str(f) for f in stac_path.rglob("*") if f.is_file()]
         else:

--- a/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/s3.py
+++ b/openeo_argoworkflows/executor/openeo_argoworkflows_executor/extra_processes/process_implementations/s3.py
@@ -61,3 +61,43 @@ def upload_to_s3(local_path: str) -> str:
     except Exception as e:
         logger.error("S3 upload failed, keeping local path. Error: %s", e)
         return local_path
+
+
+def upload_stac_item_assets(items_dir) -> int:
+    """Upload local-file assets referenced by STAC item JSONs to S3.
+
+    For every ``*.json`` STAC item in ``items_dir``, each asset whose ``href``
+    is a local file is uploaded to S3 and its ``href`` rewritten in place to the
+    returned ``s3://`` URI. No-op (returns 0) when S3 is not configured; never
+    raises — a failed upload leaves the local href untouched (see upload_to_s3).
+
+    Returns the number of assets uploaded/rewritten.
+    """
+    if not is_s3_configured():
+        return 0
+
+    import glob
+    import json
+
+    uploaded = 0
+    for item_json in glob.glob(os.path.join(str(items_dir), "*.json")):
+        try:
+            with open(item_json) as f:
+                item = json.load(f)
+        except Exception as e:
+            logger.warning("Could not read STAC item %s: %s", item_json, e)
+            continue
+        changed = False
+        for asset in item.get("assets", {}).values():
+            href = asset.get("href", "")
+            if href and os.path.isfile(href):
+                s3_uri = upload_to_s3(href)
+                if s3_uri != href:
+                    asset["href"] = s3_uri
+                    changed = True
+                    uploaded += 1
+                    logger.info("Rewrote STAC asset href %s -> %s", href, s3_uri)
+        if changed:
+            with open(item_json, "w") as f:
+                json.dump(item, f)
+    return uploaded

--- a/openeo_argoworkflows/executor/tests/test_s3_upload.py
+++ b/openeo_argoworkflows/executor/tests/test_s3_upload.py
@@ -10,6 +10,7 @@ When: upload_to_s3 runs
 Then: local file path is returned unchanged (backward compatible)
 """
 import importlib.util
+import json
 import os
 import pathlib
 import pytest
@@ -140,3 +141,57 @@ def test_upload_to_s3_key_structure(tmp_path, monkeypatch):
 
     s3_key = mock_client.upload_file.call_args[0][2]
     assert s3_key == "user-123/job-456/abc123.nc"
+
+
+# --- upload_stac_item_assets: rewrite local STAC item hrefs to S3 (CWL path) ---
+
+def _make_item(tmp_path, href, name="item1.json"):
+    items = tmp_path / "items"
+    items.mkdir(exist_ok=True)
+    p = items / name
+    p.write_text(json.dumps({"type": "Feature", "assets": {"data": {"href": href}}}))
+    return items, p
+
+
+def test_upload_stac_item_assets_rewrites_local_href_to_s3(tmp_path, monkeypatch):
+    _make_env(monkeypatch)
+    tif = tmp_path / "coh.tif"
+    tif.write_bytes(b"x")
+    items, item_json = _make_item(tmp_path, str(tif))
+
+    mod = _load_s3_module()
+    with patch.object(mod, "upload_to_s3", return_value="s3://eo-public/u/j/coh.tif") as up:
+        n = mod.upload_stac_item_assets(str(items))
+
+    assert n == 1
+    up.assert_called_once_with(str(tif))
+    saved = json.loads(item_json.read_text())
+    assert saved["assets"]["data"]["href"] == "s3://eo-public/u/j/coh.tif"
+
+
+def test_upload_stac_item_assets_noop_when_not_configured(tmp_path):
+    for var in ("S3_ENDPOINT_URL", "S3_BUCKET", "S3_ACCESS_KEY", "S3_SECRET_KEY"):
+        os.environ.pop(var, None)
+    tif = tmp_path / "coh.tif"
+    tif.write_bytes(b"x")
+    items, item_json = _make_item(tmp_path, str(tif))
+
+    mod = _load_s3_module()
+    with patch.object(mod, "upload_to_s3") as up:
+        n = mod.upload_stac_item_assets(str(items))
+
+    assert n == 0
+    up.assert_not_called()
+    assert json.loads(item_json.read_text())["assets"]["data"]["href"] == str(tif)
+
+
+def test_upload_stac_item_assets_skips_non_local_href(tmp_path, monkeypatch):
+    _make_env(monkeypatch)
+    items, item_json = _make_item(tmp_path, "s3://already/there.tif")
+
+    mod = _load_s3_module()
+    with patch.object(mod, "upload_to_s3") as up:
+        n = mod.upload_stac_item_assets(str(items))
+
+    up.assert_not_called()
+    assert n == 0


### PR DESCRIPTION
CWL/EOAP job results were collected to the workspace PVC with **local** STAC asset hrefs and never uploaded to S3 — unlike the regular `save_result` path. This wires the same S3 upload into the CWL path so outputs land in `eo-public` with `s3://` hrefs (served via the existing S3 proxy download), and are covered by the bucket lifecycle rather than only the 2-day workspace cleanup.

## Changes
- **`s3.py`** — new reusable `upload_stac_item_assets(items_dir)`: uploads each local-file STAC asset to S3 and rewrites its `href` to `s3://` in place; no-op when S3 unconfigured; never raises (failed upload keeps the local href).
- **`cwl.py`** — call it on the STAC items dir after href normalisation, in the STAC-root branch of `run_cwl`.
- **`cli.py`** — regular path refactored to use the same helper (DRY; identical behaviour, removes the duplicated inline loop).

## Why it works with no env change
S3 creds reach the executor via `--user_profile` → `cli.py` exports `S3_*` into `os.environ` for all jobs (incl. CWL), so `is_s3_configured()` is already True there. The bug was simply that the CWL path never *called* the upload.

## Tests
3 new in `test_s3_upload.py` (rewrite local→s3, no-op when unconfigured, skip non-local href); **8 total pass**. `py_compile` clean on all three modules.

## Scope note
Covers the STAC-root (EOAP) output path — the standard for these workflows. The flat/non-STAC fallback branch isn't uploaded (rare; separate follow-up if needed).