### PR TITLE
hotfix(executor): pin zarr<=2.18.7 + kerchunk<0.2.7 (fix load_stac on Zarr assets)

### DIFF
--- a/Dockerfile.executor
+++ b/Dockerfile.executor
@@ -40,8 +40,11 @@ RUN printf '#!/opt/openeo_argoworkflows_executor/.venv/bin/python\nfrom openeo_a
 
 # Install raster2stac separately to avoid pystac version conflict with openeo-processes-dask
 # Install all raster2stac deps (except pystac) with full resolution, then raster2stac with --no-deps
-RUN $VIRTUAL_ENV/bin/pip install boto3 dask fsspec h5netcdf h5py kerchunk netcdf4 numcodecs "numpy<2" \
-        pandas pydantic rasterio rio-stac rioxarray s3fs ujson xarray zarr requests && \
+# Pin zarr<=2.18.7: openeo-processes-dask requires zarr<=2.18.7 and zarr 3.x fails to import
+# (needs typing_extensions>=4.12, but calrissian pins typing_extensions==4.8.0). zarr 2.18.7
+# in turn requires numcodecs<0.16. kerchunk<0.2.7 keeps it zarr-2 compatible (0.2.7+ needs zarr 3).
+RUN $VIRTUAL_ENV/bin/pip install boto3 dask fsspec h5netcdf h5py "kerchunk<0.2.7" netcdf4 numcodecs "numpy<2" \
+        pandas pydantic rasterio rio-stac rioxarray s3fs ujson xarray "zarr<=2.18.7" requests && \
     $VIRTUAL_ENV/bin/pip install --no-deps raster2stac
 
 # Install CWL execution dependencies (calrissian for K8s CWL runner, cwltool for validation)


### PR DESCRIPTION
## Problem
`load_stac` on any Zarr-asset collection fails in prod with:
```
ImportError: cannot import name 'ReadOnly' from 'typing_extensions'
```
A recent executor rebuild pulled **zarr 3.1.5** (it was unpinned). zarr 3 needs `typing_extensions>=4.12`, but **calrissian pins `typing_extensions==4.8.0`** — so `import zarr` throws, and xarray reports "zarr package required". Found via job `22557293-bb16-459f-9281-78d196a408ec`.

## Fix
- **`zarr<=2.18.7`** — `openeo-processes-dask` already requires this; zarr 3.x was never compatible with the rest of the stack.
- zarr 2.18.7 requires **numcodecs<0.16** (auto-resolves to 0.15.1; 0.16 removed `blosc.cbuffer_sizes`).
- **`kerchunk<0.2.7`** — 0.2.7+ requires zarr>=3, so pin it back to a zarr-2-compatible release (0.2.6).

## Verification
Installed the pins into the live `:eurac-main` image and confirmed all critical imports succeed:
`zarr 2.18.7`, `kerchunk 0.2.6`, `numcodecs 0.15.1`, xarray zarr backend, `openeo_processes_dask`, `load_stac`/`_load_zarr_assets`, `raster2stac`, `calrissian`.

After merge → rebuild `:eurac-main`/`:stable` → executor auto-picks it up (Always pull). Re-test job `22557293…` against the corrected image.