### PR TITLE
hotfix(executor): bump openeo-processes-dask to v2025.5.1-eurac.2 (filter_labels fix)

### DIFF
--- a/openeo_argoworkflows/executor/poetry.lock
+++ b/openeo_argoworkflows/executor/poetry.lock
@@ -3558,8 +3558,8 @@ ml = ["xgboost (>=1.5.1,<2.1.4)"]
 [package.source]
 type = "git"
 url = "https://github.com/Eurac-Research-Institute-for-EO/openeo-processes-dask.git"
-reference = "v2025.5.1-eurac.1"
-resolved_reference = "16af5d9999f44baf5341dd966a3cd0a0b5135309"
+reference = "v2025.5.1-eurac.2"
+resolved_reference = "de100eeae45f85304af6511f612903a612281867"
 
 [[package]]
 name = "oschmod"
@@ -6670,4 +6670,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "0e5143beea8fda778f6a81b942f96874efa0fd23854e7562fc84aa7d49f3c796"
+content-hash = "2e52035ed7ce2ccc4db9f6e67a915b37e678663336b50c0448f7d698a398d199"

--- a/openeo_argoworkflows/executor/pyproject.toml
+++ b/openeo_argoworkflows/executor/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "openeo_argoworkflows_executor"}]
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
 dask-gateway = "^2024.1.0"
-openeo-processes-dask = {git = "https://github.com/Eurac-Research-Institute-for-EO/openeo-processes-dask.git", tag = "v2025.5.1-eurac.1", extras = ["implementations", "ml"]}
+openeo-processes-dask = {git = "https://github.com/Eurac-Research-Institute-for-EO/openeo-processes-dask.git", tag = "v2025.5.1-eurac.2", extras = ["implementations", "ml"]}
 openeo-pg-parser-networkx = ">=2024.4.0"
 pystac-client = ">=0.8.2,<1"
 click = ">=8.1.7"


### PR DESCRIPTION
Pulls in the `filter_labels` fix from openeo-processes-dask **PR #19** (tag `v2025.5.1-eurac.2`).

`filter_labels` raised `IndexError` when selecting a non-first label (e.g. `rcp==8.5` in `[4.5, 8.5]`); now fixed.

- pyproject tag `v2025.5.1-eurac.1` → `v2025.5.1-eurac.2`
- poetry.lock `reference`/`resolved_reference` (`de100ee…`) + content-hash updated
- No other dependency changes; `poetry check --lock` passes.

Merging rebuilds `:eurac-main`/`:stable` (executor build path); the executor auto-picks it up on next job (Always pull).