### PR TITLE
hotfix(executor): pin openeo-processes-dask to eurac.1.1 (fix broken eurac.2 build)

### DIFF
--- a/openeo_argoworkflows/executor/poetry.lock
+++ b/openeo_argoworkflows/executor/poetry.lock
@@ -3558,8 +3558,8 @@ ml = ["xgboost (>=1.5.1,<2.1.4)"]
 [package.source]
 type = "git"
 url = "https://github.com/Eurac-Research-Institute-for-EO/openeo-processes-dask.git"
-reference = "v2025.5.1-eurac.2"
-resolved_reference = "de100eeae45f85304af6511f612903a612281867"
+reference = "v2025.5.1-eurac.1.1"
+resolved_reference = "7884517857bf58e3a4a03fd6f7b3f72fb690ffe9"
 
 [[package]]
 name = "oschmod"
@@ -6670,4 +6670,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "2e52035ed7ce2ccc4db9f6e67a915b37e678663336b50c0448f7d698a398d199"
+content-hash = "49770358364ae3e7ec9cc34fe932e1cef68549904c15ad894ffd1308c4e12083"

--- a/openeo_argoworkflows/executor/pyproject.toml
+++ b/openeo_argoworkflows/executor/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "openeo_argoworkflows_executor"}]
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
 dask-gateway = "^2024.1.0"
-openeo-processes-dask = {git = "https://github.com/Eurac-Research-Institute-for-EO/openeo-processes-dask.git", tag = "v2025.5.1-eurac.2", extras = ["implementations", "ml"]}
+openeo-processes-dask = {git = "https://github.com/Eurac-Research-Institute-for-EO/openeo-processes-dask.git", tag = "v2025.5.1-eurac.1.1", extras = ["implementations", "ml"]}
 openeo-pg-parser-networkx = ">=2024.4.0"
 pystac-client = ">=0.8.2,<1"
 click = ">=8.1.7"


### PR DESCRIPTION
PR #137 bumped to `v2025.5.1-eurac.2`, but that tag = the tip of the fork's `eurac-main`, which includes an unrelated **dependency modernization** (version 2026.6.1: NumPy 2, `gdal>=3.8.4` now in the `implementations` extra, Python 3.13). The executor image has system libgdal **3.6.2** + numpy<2, so the build failed trying to compile gdal.

`v2025.5.1-eurac.1.1` is **eurac.1 + only the filter_labels fix** (cherry-picked from PR #19) — identical dependencies to eurac.1, just the bug fix. Minimal lock change (ref + resolved_reference + content-hash); `poetry check --lock` passes.