### PR TITLE
feat(auth): advertise dev.openeo.eurac.edu/editor OIDC redirect URL

### DIFF
--- a/openeo_argoworkflows/api/openeo_argoworkflows_api/auth.py
+++ b/openeo_argoworkflows/api/openeo_argoworkflows_api/auth.py
@@ -250,6 +250,7 @@ def get_credentials_oidc() -> Response:
                             "https://editor.openeo.org",
                             "http://localhost:1410/",
                             "https://openeo.eurac.edu/editor/",
+                            "https://dev.openeo.eurac.edu/editor/",
                         ],
                         grant_types=[
                             GrantType.authorization_code_pkce,

--- a/openeo_argoworkflows/api/patches/openeo_fastapi_core.py
+++ b/openeo_argoworkflows/api/patches/openeo_fastapi_core.py
@@ -156,6 +156,7 @@ class OpenEOCore:
                                 "http://10.8.244.73:8080/",
                                 "http://localhost:8080/",
                                 "https://openeo.eurac.edu/editor/",
+                                "https://dev.openeo.eurac.edu/editor/",
                             ],
                             grant_types=[
                                 GrantType.authorization_code_pkce,


### PR DESCRIPTION
Adds `https://dev.openeo.eurac.edu/editor/` to the `openeo-platform-default-client` `redirect_urls` (in `auth.py` and the `openeo_fastapi_core` patch).

Without it the **dev** Web Editor (now served at dev.openeo.eurac.edu/editor) can't auto-use the default client and prompts for a Client ID. Mirrors the existing prod `openeo.eurac.edu/editor` entry.

After merge: fast-forward `dev` to eurac-main → `:dev` API rebuilds with this (and the 10 pending eurac-main fixes). Keycloak redirect URI already registered.